### PR TITLE
Add stories for builder components

### DIFF
--- a/src/stories/Calendar.stories.tsx
+++ b/src/stories/Calendar.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { getLocalTimeZone, today } from '@internationalized/date';
+import { Calendar } from '../builder/components/Calendar';
+
+const meta: Meta<typeof Calendar> = {
+  title: 'Calendar',
+  component: Calendar,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Calendar>;
+
+export const Basic: Story = {
+  render: (args) => (
+    <Calendar {...args} defaultValue={today(getLocalTimeZone())} />
+  )
+};
+
+export const WithMinMax: Story = {
+  render: (args) => (
+    <Calendar
+      {...args}
+      minValue={today(getLocalTimeZone()).subtract({ days: 5 })}
+      maxValue={today(getLocalTimeZone()).add({ days: 5 })}
+      defaultValue={today(getLocalTimeZone())}
+    />
+  )
+};
+
+export const WithError: Story = {
+  render: (args) => (
+    <Calendar
+      {...args}
+      isInvalid
+      errorMessage="Date is outside the allowed range"
+      minValue={today(getLocalTimeZone()).add({ days: 2 })}
+      defaultValue={today(getLocalTimeZone())}
+    />
+  )
+};

--- a/src/stories/Card.stories.tsx
+++ b/src/stories/Card.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Card } from '../builder/components/Card';
+
+const meta: Meta<typeof Card> = {
+  title: 'Card',
+  component: Card,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    title: 'Project Aurora',
+    description: 'A design system exploration for next generation products.'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Card>;
+
+export const Basic: Story = {};
+
+export const Elevated: Story = {
+  args: {
+    variant: 'elevated',
+    children: (
+      <div className="space-y-2">
+        <p>A card with elevation styling.</p>
+        <button className="px-3 py-1 rounded bg-blue-600 text-white">Open project</button>
+      </div>
+    )
+  }
+};
+
+export const QuietSelection: Story = {
+  args: {
+    isQuiet: true,
+    isSelected: true,
+    children: (
+      <div className="space-y-2">
+        <p>Selected state with quiet appearance.</p>
+        <span className="text-sm text-gray-500">Last updated 2 hours ago</span>
+      </div>
+    )
+  }
+};

--- a/src/stories/Checkbox.stories.tsx
+++ b/src/stories/Checkbox.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Checkbox } from '../builder/components/Checkbox';
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'Checkbox',
+  component: Checkbox,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    children: 'Subscribe to newsletter'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Checkbox>;
+
+export const Basic: Story = {};
+
+export const Indeterminate: Story = {
+  args: {
+    children: 'Partially selected',
+    isIndeterminate: true
+  }
+};
+
+export const Disabled: Story = {
+  args: {
+    children: 'Disabled option',
+    isDisabled: true
+  }
+};

--- a/src/stories/CheckboxGroup.stories.tsx
+++ b/src/stories/CheckboxGroup.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Checkbox } from '../builder/components/Checkbox';
+import { CheckboxGroup } from '../builder/components/CheckboxGroup';
+
+const meta: Meta<typeof CheckboxGroup> = {
+  title: 'CheckboxGroup',
+  component: CheckboxGroup,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    label: 'Newsletter topics'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CheckboxGroup>;
+
+export const Basic: Story = {
+  render: (args) => (
+    <CheckboxGroup {...args}>
+      <Checkbox value="updates">Product updates</Checkbox>
+      <Checkbox value="events">Events</Checkbox>
+      <Checkbox value="offers">Special offers</Checkbox>
+    </CheckboxGroup>
+  )
+};
+
+export const Horizontal: Story = {
+  render: (args) => (
+    <CheckboxGroup {...args} orientation="horizontal">
+      <Checkbox value="coffee">Coffee</Checkbox>
+      <Checkbox value="tea">Tea</Checkbox>
+      <Checkbox value="juice">Juice</Checkbox>
+    </CheckboxGroup>
+  )
+};

--- a/src/stories/ComboBox.stories.tsx
+++ b/src/stories/ComboBox.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import type { ComponentProps } from 'react';
+import { ComboBox, ComboBoxItem } from '../builder/components/ComboBox';
+
+const fruits = [
+  { id: 'apple', name: 'Apple' },
+  { id: 'banana', name: 'Banana' },
+  { id: 'cherry', name: 'Cherry' },
+  { id: 'grape', name: 'Grape' },
+  { id: 'orange', name: 'Orange' }
+];
+
+function ControlledComboBox(props: ComponentProps<typeof ComboBox>) {
+  const [inputValue, setInputValue] = useState('');
+
+  return (
+    <ComboBox
+      {...props}
+      inputValue={inputValue}
+      onInputChange={setInputValue}
+      items={fruits}
+    >
+      {(item: { id: string; name: string }) => (
+        <ComboBoxItem key={item.id}>{item.name}</ComboBoxItem>
+      )}
+    </ComboBox>
+  );
+}
+
+const meta: Meta<typeof ComboBox> = {
+  title: 'ComboBox',
+  component: ComboBox,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    label: 'Choose a fruit',
+    placeholder: 'Type or select a fruit'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ComboBox>;
+
+export const Basic: Story = {
+  render: (args) => (
+    <ComboBox {...args} items={fruits}>
+      {(item) => <ComboBoxItem key={item.id}>{item.name}</ComboBoxItem>}
+    </ComboBox>
+  )
+};
+
+export const WithControlledValue: Story = {
+  render: (args) => <ControlledComboBox {...args} />
+};

--- a/src/stories/DatePicker.stories.tsx
+++ b/src/stories/DatePicker.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { parseDate } from '@internationalized/date';
+import { DatePicker } from '../builder/components/DatePicker';
+
+const meta: Meta<typeof DatePicker> = {
+  title: 'DatePicker',
+  component: DatePicker,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    label: 'Select a date'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DatePicker>;
+
+export const Basic: Story = {
+  render: (args) => (
+    <DatePicker {...args} defaultValue={parseDate('2024-05-15')} />
+  )
+};
+
+export const WithDescription: Story = {
+  render: (args) => (
+    <DatePicker
+      {...args}
+      description="Choose when the event should take place."
+      minValue={parseDate('2024-05-01')}
+      maxValue={parseDate('2024-05-31')}
+      defaultValue={parseDate('2024-05-15')}
+    />
+  )
+};
+
+export const WithTimeSelection: Story = {
+  render: (args) => (
+    <DatePicker
+      {...args}
+      includeTime
+      timeFormat="24h"
+      timeLabel="Time"
+      defaultValue={parseDate('2024-05-15')}
+    />
+  )
+};

--- a/src/stories/DateRangePicker.stories.tsx
+++ b/src/stories/DateRangePicker.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { parseDate } from '@internationalized/date';
+import { DateRangePicker } from '../builder/components/DateRangePicker';
+
+const meta: Meta<typeof DateRangePicker> = {
+  title: 'DateRangePicker',
+  component: DateRangePicker,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    label: 'Select a date range'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DateRangePicker>;
+
+export const Basic: Story = {
+  render: (args) => (
+    <DateRangePicker
+      {...args}
+      defaultValue={{
+        start: parseDate('2024-06-10'),
+        end: parseDate('2024-06-15')
+      }}
+    />
+  )
+};
+
+export const WithDescription: Story = {
+  render: (args) => (
+    <DateRangePicker
+      {...args}
+      description="Plan your vacation period."
+      minValue={parseDate('2024-06-01')}
+      maxValue={parseDate('2024-06-30')}
+      defaultValue={{
+        start: parseDate('2024-06-12'),
+        end: parseDate('2024-06-18')
+      }}
+    />
+  )
+};
+
+export const WithTimeSelection: Story = {
+  render: (args) => (
+    <DateRangePicker
+      {...args}
+      includeTime
+      timeFormat="24h"
+      startTimeLabel="Start time"
+      endTimeLabel="End time"
+      defaultValue={{
+        start: parseDate('2024-06-12'),
+        end: parseDate('2024-06-13')
+      }}
+    />
+  )
+};

--- a/src/stories/Field.stories.tsx
+++ b/src/stories/Field.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  FieldGroup,
+  Label,
+  Input,
+  Description,
+  FieldError
+} from '../builder/components/Field';
+
+const meta: Meta<typeof FieldGroup> = {
+  title: 'Field',
+  component: FieldGroup,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FieldGroup>;
+
+export const Basic: Story = {
+  render: () => (
+    <FieldGroup className="flex flex-col gap-2 max-w-sm">
+      <Label htmlFor="field-basic">Label</Label>
+      <Input id="field-basic" placeholder="Type something" />
+      <Description>Helpful instructions for the input.</Description>
+    </FieldGroup>
+  )
+};
+
+export const WithErrorState: Story = {
+  render: () => (
+    <FieldGroup
+      aria-describedby="field-error"
+      aria-invalid
+      className="flex flex-col gap-2 max-w-sm"
+    >
+      <Label htmlFor="field-error-input">Email</Label>
+      <Input id="field-error-input" placeholder="you@example.com" />
+      <FieldError id="field-error">Please provide a valid email.</FieldError>
+    </FieldGroup>
+  )
+};

--- a/src/stories/GridList.stories.tsx
+++ b/src/stories/GridList.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { GridList, GridListItem } from '../builder/components/GridList';
+
+interface FileItem {
+  id: string;
+  name: string;
+  type: string;
+  size: string;
+}
+
+const files: FileItem[] = [
+  { id: '1', name: 'Photos', type: 'Folder', size: '1.2 GB' },
+  { id: '2', name: 'Videos', type: 'Folder', size: '5.4 GB' },
+  { id: '3', name: 'Presentation.pptx', type: 'PowerPoint', size: '24 MB' },
+  { id: '4', name: 'Budget.xlsx', type: 'Excel', size: '4.5 MB' }
+];
+
+const meta: Meta<typeof GridList> = {
+  title: 'GridList',
+  component: GridList,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    selectionMode: 'multiple'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GridList>;
+
+export const Basic: Story = {
+  render: (args) => (
+    <GridList {...args} items={files} aria-label="Project files" className="max-w-md w-full">
+      {(item: FileItem) => (
+        <GridListItem key={item.id}>
+          <div className="flex flex-col gap-1">
+            <span className="font-medium">{item.name}</span>
+            <span className="text-sm text-gray-500">{item.type} • {item.size}</span>
+          </div>
+        </GridListItem>
+      )}
+    </GridList>
+  )
+};
+
+export const WithSingleSelection: Story = {
+  render: (args) => (
+    <GridList
+      {...args}
+      selectionMode="single"
+      items={files}
+      aria-label="Project files"
+      className="max-w-md w-full"
+    >
+      {(item: FileItem) => (
+        <GridListItem key={item.id}>
+          <div className="flex flex-col gap-1">
+            <span className="font-medium">{item.name}</span>
+            <span className="text-sm text-gray-500">{item.type} • {item.size}</span>
+          </div>
+        </GridListItem>
+      )}
+    </GridList>
+  )
+};

--- a/src/stories/Panel.stories.tsx
+++ b/src/stories/Panel.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Panel } from '../builder/components/Panel';
+
+const meta: Meta<typeof Panel> = {
+  title: 'Panel',
+  component: Panel,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    title: 'Panel Title',
+    children: 'This is panel content.'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Panel>;
+
+export const Basic: Story = {};
+
+export const Sidebar: Story = {
+  args: {
+    variant: 'sidebar',
+    title: 'Sidebar panel',
+    children: (
+      <ul className="space-y-2">
+        <li>Dashboard</li>
+        <li>Projects</li>
+        <li>Settings</li>
+      </ul>
+    )
+  }
+};
+
+export const ModalStyle: Story = {
+  args: {
+    variant: 'modal',
+    title: 'Confirm action',
+    children: (
+      <div className="space-y-3">
+        <p>Are you sure you want to proceed?</p>
+        <div className="flex gap-2">
+          <button className="px-3 py-1 rounded bg-blue-600 text-white">Confirm</button>
+          <button className="px-3 py-1 rounded border">Cancel</button>
+        </div>
+      </div>
+    )
+  }
+};

--- a/src/stories/Radio.stories.tsx
+++ b/src/stories/Radio.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Radio } from '../builder/components/Radio';
+import { RadioGroup } from '../builder/components/RadioGroup';
+
+const meta: Meta<typeof Radio> = {
+  title: 'Radio',
+  component: Radio,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    isDisabled: false
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Radio>;
+
+export const Example: Story = {
+  render: (args) => (
+    <RadioGroup label="Favorite fruit" defaultValue="apple">
+      <Radio {...args} value="apple">Apple</Radio>
+      <Radio {...args} value="orange">Orange</Radio>
+      <Radio {...args} value="pear">Pear</Radio>
+    </RadioGroup>
+  )
+};
+
+export const Horizontal: Story = {
+  render: (args) => (
+    <RadioGroup label="Delivery speed" orientation="horizontal" defaultValue="standard">
+      <Radio {...args} value="standard">Standard</Radio>
+      <Radio {...args} value="express">Express</Radio>
+      <Radio {...args} value="overnight">Overnight</Radio>
+    </RadioGroup>
+  )
+};

--- a/src/stories/Switch.stories.tsx
+++ b/src/stories/Switch.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Switch } from '../builder/components/Switch';
+
+const meta: Meta<typeof Switch> = {
+  title: 'Switch',
+  component: Switch,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    children: 'Enable notifications'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Switch>;
+
+export const Basic: Story = {};
+
+export const Disabled: Story = {
+  args: {
+    children: 'Disabled switch',
+    isDisabled: true
+  }
+};
+
+export const Selected: Story = {
+  args: {
+    children: 'Switch on by default',
+    defaultSelected: true
+  }
+};

--- a/src/stories/Table.stories.tsx
+++ b/src/stories/Table.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Cell, TableBody } from 'react-aria-components';
+import { Column, Row, Table, TableHeader } from '../builder/components/Table';
+
+interface Person {
+  id: string;
+  name: string;
+  role: string;
+  status: string;
+}
+
+const columns = [
+  { id: 'name', name: 'Name' },
+  { id: 'role', name: 'Role' },
+  { id: 'status', name: 'Status' }
+] as const;
+
+const rows: Person[] = [
+  { id: '1', name: 'Alice', role: 'Designer', status: 'Active' },
+  { id: '2', name: 'Bob', role: 'Developer', status: 'Away' },
+  { id: '3', name: 'Charlie', role: 'Product Manager', status: 'Offline' }
+];
+
+const meta: Meta<typeof Table> = {
+  title: 'Table',
+  component: Table,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    selectionMode: 'none'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Table>;
+
+export const Basic: Story = {
+  render: (args) => (
+    <Table {...args} aria-label="Team members" className="w-[480px]">
+      <TableHeader columns={columns}>
+        {(column) => <Column>{column.name}</Column>}
+      </TableHeader>
+      <TableBody items={rows}>
+        {(item) => (
+          <Row id={item.id} columns={columns}>
+            {(column) => <Cell>{item[column.id as keyof Person]}</Cell>}
+          </Row>
+        )}
+      </TableBody>
+    </Table>
+  )
+};
+
+export const WithSelection: Story = {
+  render: (args) => (
+    <Table
+      {...args}
+      selectionMode="multiple"
+      aria-label="Selectable team members"
+      className="w-[480px]"
+    >
+      <TableHeader columns={columns}>
+        {(column) => <Column allowsSorting={column.id === 'name'}>{column.name}</Column>}
+      </TableHeader>
+      <TableBody items={rows}>
+        {(item) => (
+          <Row id={item.id} columns={columns}>
+            {(column) => <Cell>{item[column.id as keyof Person]}</Cell>}
+          </Row>
+        )}
+      </TableBody>
+    </Table>
+  )
+};

--- a/src/stories/Tabs.stories.tsx
+++ b/src/stories/Tabs.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tab, TabList, TabPanel, Tabs } from '../builder/components/Tabs';
+
+const meta: Meta<typeof Tabs> = {
+  title: 'Tabs',
+  component: Tabs,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    selectedKey: 'overview'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tabs>;
+
+export const Basic: Story = {
+  render: (args) => (
+    <Tabs {...args} className="w-[360px]">
+      <TabList aria-label="Project sections">
+        <Tab id="overview">Overview</Tab>
+        <Tab id="details">Details</Tab>
+        <Tab id="activity">Activity</Tab>
+      </TabList>
+      <TabPanel id="overview">Overview content goes here.</TabPanel>
+      <TabPanel id="details">Detailed information appears here.</TabPanel>
+      <TabPanel id="activity">Recent activity is shown here.</TabPanel>
+    </Tabs>
+  )
+};
+
+export const DisabledTab: Story = {
+  render: (args) => (
+    <Tabs {...args} className="w-[360px]" selectedKey="overview">
+      <TabList aria-label="Settings">
+        <Tab id="general">General</Tab>
+        <Tab id="security" isDisabled>Security</Tab>
+        <Tab id="notifications">Notifications</Tab>
+      </TabList>
+      <TabPanel id="general">General settings form.</TabPanel>
+      <TabPanel id="security">Security options are disabled.</TabPanel>
+      <TabPanel id="notifications">Notification preferences.</TabPanel>
+    </Tabs>
+  )
+};

--- a/src/stories/TagGroup.stories.tsx
+++ b/src/stories/TagGroup.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { Tag, TagGroup } from '../builder/components/TagGroup';
+
+interface TagItem {
+  id: string;
+  name: string;
+}
+
+const tags: TagItem[] = [
+  { id: 'design', name: 'Design' },
+  { id: 'development', name: 'Development' },
+  { id: 'marketing', name: 'Marketing' }
+];
+
+const meta: Meta<typeof TagGroup> = {
+  title: 'TagGroup',
+  component: TagGroup,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    label: 'Team focus'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TagGroup>;
+
+export const Basic: Story = {
+  render: (args) => (
+    <TagGroup {...args} items={tags}>
+      {(item: TagItem) => <Tag key={item.id}>{item.name}</Tag>}
+    </TagGroup>
+  )
+};
+
+export const Removable: Story = {
+  render: (args) => (
+    <TagGroup {...args} items={tags} allowsRemoving onRemove={action('remove')}>
+      {(item: TagItem) => <Tag key={item.id}>{item.name}</Tag>}
+    </TagGroup>
+  )
+};
+
+export const Selectable: Story = {
+  render: (args) => (
+    <TagGroup
+      {...args}
+      items={tags}
+      selectionMode="multiple"
+      defaultSelectedKeys={['design']}
+    >
+      {(item: TagItem) => <Tag key={item.id}>{item.name}</Tag>}
+    </TagGroup>
+  )
+};

--- a/src/stories/Tree.stories.tsx
+++ b/src/stories/Tree.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { Tree, TreeItem } from '../builder/components/Tree';
+
+const meta: Meta<typeof Tree> = {
+  title: 'Tree',
+  component: Tree,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  args: {
+    selectionMode: 'multiple'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tree>;
+
+export const Basic: Story = {
+  render: (args) => (
+    <Tree {...args} aria-label="Project navigator" className="w-[280px]">
+      <TreeItem id="getting-started" title="Getting Started" hasChildren childItems={(
+        <>
+          <TreeItem id="overview" title="Overview" />
+          <TreeItem id="quickstart" title="Quickstart" />
+        </>
+      )} />
+      <TreeItem id="guides" title="Guides" hasChildren childItems={(
+        <>
+          <TreeItem id="styling" title="Styling" />
+          <TreeItem id="routing" title="Routing" />
+          <TreeItem id="state" title="State Management" />
+        </>
+      )} />
+      <TreeItem id="api" title="API Reference" />
+    </Tree>
+  )
+};
+
+export const WithActions: Story = {
+  render: (args) => (
+    <Tree {...args} aria-label="Folders" className="w-[280px]">
+      <TreeItem
+        id="projects"
+        title="Projects"
+        hasChildren
+        onInfoClick={action('projects-info-click')}
+        childItems={(
+          <>
+            <TreeItem id="project-alpha" title="Alpha" />
+            <TreeItem id="project-beta" title="Beta" />
+          </>
+        )}
+      />
+      <TreeItem
+        id="archive"
+        title="Archive"
+        hasChildren
+        childItems={<TreeItem id="old" title="2019" />}
+      />
+    </Tree>
+  )
+};


### PR DESCRIPTION
## Summary
- add Storybook stories for every registered builder component without coverage
- provide usage examples for complex inputs like ComboBox, date pickers, grid lists, tables, and tag groups
- demonstrate component variations such as selection, error, and controlled states in new stories

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68cffdf95a0c8333a2dfaf8c7b06fe07