### PR TITLE
Implement Preview Runtime isolation (Phase 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:preview-runtime": "vite build --config vite.preview.config.ts",
+    "build:all": "npm run build:preview-runtime && npm run build",
     "lint": "eslint src --ext .ts,.tsx",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",

--- a/src/builder/main/previewSrcdoc.ts
+++ b/src/builder/main/previewSrcdoc.ts
@@ -131,15 +131,31 @@ export function generatePreviewSrcdoc(projectId: string): string {
 /**
  * Preview iframe이 srcdoc 모드를 사용해야 하는지 여부
  *
- * 테스트 방법:
- * 1. 브라우저 콘솔에서: window.__USE_SRCDOC__ = true
- * 2. 또는 이 함수에서 직접 return true
- *
- * 현재는 false로 설정하여 기존 src 방식 유지
+ * 테스트 방법 (한 번만 설정하면 유지됨):
+ * - 활성화: localStorage.setItem('USE_SRCDOC', 'true')
+ * - 비활성화: localStorage.removeItem('USE_SRCDOC')
+ * - 또는 URL 파라미터: ?srcdoc=true
  */
 export function shouldUseSrcdoc(): boolean {
-  // 브라우저 콘솔에서 테스트: window.__USE_SRCDOC__ = true
-  if (typeof window !== 'undefined' && (window as unknown as { __USE_SRCDOC__?: boolean }).__USE_SRCDOC__) {
+  if (typeof window === 'undefined') return false;
+
+  // 1. URL 파라미터 체크 (?srcdoc=true)
+  const urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.get('srcdoc') === 'true') {
+    return true;
+  }
+
+  // 2. localStorage 체크 (한 번 설정하면 브라우저 닫아도 유지)
+  try {
+    if (localStorage.getItem('USE_SRCDOC') === 'true') {
+      return true;
+    }
+  } catch {
+    // localStorage 접근 불가 시 무시
+  }
+
+  // 3. 전역 변수 체크 (레거시 지원)
+  if ((window as unknown as { __USE_SRCDOC__?: boolean }).__USE_SRCDOC__) {
     return true;
   }
 

--- a/src/builder/main/previewSrcdoc.ts
+++ b/src/builder/main/previewSrcdoc.ts
@@ -130,11 +130,19 @@ export function generatePreviewSrcdoc(projectId: string): string {
 
 /**
  * Preview iframe이 srcdoc 모드를 사용해야 하는지 여부
+ *
+ * 테스트 방법:
+ * 1. 브라우저 콘솔에서: window.__USE_SRCDOC__ = true
+ * 2. 또는 이 함수에서 직접 return true
+ *
  * 현재는 false로 설정하여 기존 src 방식 유지
- * Phase 1 완료 후 true로 변경
  */
 export function shouldUseSrcdoc(): boolean {
+  // 브라우저 콘솔에서 테스트: window.__USE_SRCDOC__ = true
+  if (typeof window !== 'undefined' && (window as unknown as { __USE_SRCDOC__?: boolean }).__USE_SRCDOC__) {
+    return true;
+  }
+
   // TODO: Phase 1 완료 후 true로 변경
-  // return true;
   return false;
 }

--- a/src/builder/main/previewSrcdoc.ts
+++ b/src/builder/main/previewSrcdoc.ts
@@ -1,0 +1,140 @@
+/**
+ * Preview Srcdoc Generator
+ *
+ * Preview Runtime을 srcdoc로 생성합니다.
+ * 개발 모드와 프로덕션 모드에서 다른 방식을 사용합니다.
+ */
+
+// ============================================
+// Base HTML Template
+// ============================================
+
+const BASE_STYLES = `
+  * { box-sizing: border-box; }
+  html, body, #preview-root {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+  }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    line-height: 1.5;
+  }
+  .preview-container { width: 100%; min-height: 100%; }
+  .preview-body { width: 100%; min-height: 100%; }
+  .preview-empty, .preview-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #666;
+    font-size: 14px;
+  }
+`;
+
+// ============================================
+// Development Mode: Load from URL
+// ============================================
+
+/**
+ * 개발 모드용 srcdoc 생성
+ * preview-runtime 모듈을 동적으로 import합니다.
+ */
+export function generateDevSrcdoc(projectId: string): string {
+  // 개발 모드에서는 ESM import를 사용하여 HMR 지원
+  return `
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>XStudio Preview</title>
+  <style>${BASE_STYLES}</style>
+</head>
+<body data-preview="true" data-project-id="${projectId}">
+  <div id="preview-root">
+    <div class="preview-loading">Loading Preview Runtime...</div>
+  </div>
+  <script type="module">
+    // 개발 모드: preview-runtime을 동적 import
+    import('/src/preview-runtime/index.tsx').catch(err => {
+      console.error('[Preview] Failed to load preview-runtime:', err);
+      document.getElementById('preview-root').innerHTML =
+        '<div class="preview-loading">Failed to load Preview Runtime</div>';
+    });
+  </script>
+</body>
+</html>
+`;
+}
+
+// ============================================
+// Production Mode: Inline Bundle
+// ============================================
+
+// 빌드된 preview-runtime 번들 (빌드 시 주입됨)
+let previewRuntimeBundle: string | null = null;
+let previewRuntimeCSS: string | null = null;
+
+/**
+ * 프로덕션 빌드된 번들 설정
+ * 빌드 프로세스에서 호출됩니다.
+ */
+export function setPreviewRuntimeBundle(js: string, css?: string): void {
+  previewRuntimeBundle = js;
+  previewRuntimeCSS = css || null;
+}
+
+/**
+ * 프로덕션 모드용 srcdoc 생성
+ * 빌드된 번들을 인라인으로 포함합니다.
+ */
+export function generateProdSrcdoc(projectId: string): string {
+  if (!previewRuntimeBundle) {
+    console.warn('[Preview] Production bundle not available, falling back to dev mode');
+    return generateDevSrcdoc(projectId);
+  }
+
+  return `
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>XStudio Preview</title>
+  <style>${BASE_STYLES}</style>
+  ${previewRuntimeCSS ? `<style>${previewRuntimeCSS}</style>` : ''}
+</head>
+<body data-preview="true" data-project-id="${projectId}">
+  <div id="preview-root"></div>
+  <script>${previewRuntimeBundle}</script>
+</body>
+</html>
+`;
+}
+
+// ============================================
+// Main Export
+// ============================================
+
+/**
+ * 환경에 따른 srcdoc 생성
+ */
+export function generatePreviewSrcdoc(projectId: string): string {
+  if (import.meta.env.DEV) {
+    return generateDevSrcdoc(projectId);
+  }
+  return generateProdSrcdoc(projectId);
+}
+
+/**
+ * Preview iframe이 srcdoc 모드를 사용해야 하는지 여부
+ * 현재는 false로 설정하여 기존 src 방식 유지
+ * Phase 1 완료 후 true로 변경
+ */
+export function shouldUseSrcdoc(): boolean {
+  // TODO: Phase 1 완료 후 true로 변경
+  // return true;
+  return false;
+}

--- a/src/preview-runtime/PreviewApp.tsx
+++ b/src/preview-runtime/PreviewApp.tsx
@@ -1,0 +1,291 @@
+/**
+ * Preview App - Preview Runtime 메인 컴포넌트
+ *
+ * srcdoc iframe 내에서 독립적으로 실행되는 Preview 앱입니다.
+ * Builder와 완전히 분리된 React 앱으로 동작합니다.
+ */
+
+import React, { useEffect, useCallback, useMemo, useState, useRef } from 'react';
+import { usePreviewStore, getPreviewStore } from './store';
+import { PreviewRouter, setGlobalNavigate } from './router';
+import { MessageHandler, messageSender } from './messaging';
+import type { PreviewElement } from './store/types';
+import { useNavigate } from 'react-router-dom';
+
+// ============================================
+// Element Renderer (기존 Preview 로직 재사용)
+// ============================================
+
+interface RenderContext {
+  elements: PreviewElement[];
+  renderElement: (el: PreviewElement, key?: string) => React.ReactNode;
+}
+
+// ============================================
+// Preview Content Component
+// ============================================
+
+function PreviewContent() {
+  const elements = usePreviewStore((s) => s.elements);
+  const navigate = useNavigate();
+
+  // navigate 함수를 전역으로 설정 (EventEngine에서 사용)
+  useEffect(() => {
+    setGlobalNavigate(navigate);
+  }, [navigate]);
+
+  // Computed style 수집
+  const collectComputedStyle = useCallback((domElement: Element): Record<string, string> => {
+    const computed = window.getComputedStyle(domElement);
+    return {
+      display: computed.display,
+      width: computed.width,
+      height: computed.height,
+      position: computed.position,
+      flexDirection: computed.flexDirection,
+      justifyContent: computed.justifyContent,
+      alignItems: computed.alignItems,
+      gap: computed.gap,
+      padding: computed.padding,
+      paddingTop: computed.paddingTop,
+      paddingRight: computed.paddingRight,
+      paddingBottom: computed.paddingBottom,
+      paddingLeft: computed.paddingLeft,
+      margin: computed.margin,
+      marginTop: computed.marginTop,
+      marginRight: computed.marginRight,
+      marginBottom: computed.marginBottom,
+      marginLeft: computed.marginLeft,
+      backgroundColor: computed.backgroundColor,
+      color: computed.color,
+      fontSize: computed.fontSize,
+      fontWeight: computed.fontWeight,
+      borderRadius: computed.borderRadius,
+    };
+  }, []);
+
+  // 클릭 핸들러
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
+    const elementWithId = target.closest('[data-element-id]');
+
+    if (!elementWithId) return;
+
+    const elementId = elementWithId.getAttribute('data-element-id');
+    if (!elementId) return;
+
+    const element = elements.find((el) => el.id === elementId);
+    if (!element) return;
+
+    const isMultiSelect = e.metaKey || e.ctrlKey;
+    const rect = elementWithId.getBoundingClientRect();
+
+    // 선택 알림 전송
+    messageSender.sendElementSelected(
+      elementId,
+      {
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+      },
+      {
+        isMultiSelect,
+        props: element.props,
+        style: element.props?.style as Record<string, unknown>,
+      }
+    );
+
+    // Computed style 전송 (RAF로 지연)
+    requestAnimationFrame(() => {
+      const computedStyle = collectComputedStyle(elementWithId);
+      messageSender.sendComputedStyle(elementId, computedStyle);
+    });
+  }, [elements, collectComputedStyle]);
+
+  // 링크 클릭 가로채기
+  const handleLinkClick = useCallback((e: MouseEvent) => {
+    const target = e.target as HTMLElement;
+    const anchor = target.closest('a');
+
+    if (!anchor) return;
+
+    const href = anchor.getAttribute('href');
+    if (!href) return;
+
+    // target="_blank"는 기본 동작 허용
+    if (anchor.getAttribute('target') === '_blank') return;
+
+    // 앵커 링크는 기본 동작 허용
+    if (href.startsWith('#')) return;
+
+    // 외부 URL 패턴
+    const externalUrlPattern = /^(https?:\/\/|\/\/|mailto:|tel:|javascript:)/i;
+    const isExternal = externalUrlPattern.test(href);
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (isExternal) {
+      // 외부 링크: 새 탭에서 열기
+      window.open(href, '_blank', 'noopener,noreferrer');
+    } else {
+      // 내부 링크: MemoryRouter로 직접 네비게이션
+      navigate(href);
+    }
+  }, [navigate]);
+
+  // 링크 클릭 리스너 등록
+  useEffect(() => {
+    document.addEventListener('click', handleLinkClick, true);
+    return () => {
+      document.removeEventListener('click', handleLinkClick, true);
+    };
+  }, [handleLinkClick]);
+
+  // Element 렌더링 함수
+  const renderElement = useCallback((el: PreviewElement, key?: string): React.ReactNode => {
+    const effectiveTag = el.tag === 'body' ? 'div' : el.tag;
+
+    // 자식 요소 찾기
+    const children = elements
+      .filter((child) => child.parent_id === el.id)
+      .sort((a, b) => (a.order_num || 0) - (b.order_num || 0));
+
+    // Props 정리
+    const cleanProps: Record<string, unknown> = {
+      key: key || el.id,
+      'data-element-id': el.id,
+      style: el.props?.style,
+      className: el.props?.className,
+    };
+
+    if (el.tag === 'body') {
+      cleanProps['data-original-tag'] = 'body';
+    }
+
+    // 자식 콘텐츠
+    const content = children.length > 0
+      ? children.map((child) => renderElement(child, child.id))
+      : el.props?.children;
+
+    // HTML 요소로 렌더링
+    return React.createElement(
+      effectiveTag.toLowerCase(),
+      cleanProps,
+      content
+    );
+  }, [elements]);
+
+  // Elements 트리 렌더링
+  const renderElementsTree = useCallback(() => {
+    const bodyElement = elements.find((el) => el.tag === 'body');
+
+    if (bodyElement) {
+      const bodyChildren = elements
+        .filter((el) => el.parent_id === bodyElement.id)
+        .sort((a, b) => (a.order_num || 0) - (b.order_num || 0));
+
+      return (
+        <div
+          key={bodyElement.id}
+          data-element-id={bodyElement.id}
+          data-original-tag="body"
+          style={bodyElement.props?.style as React.CSSProperties}
+          className="preview-body"
+        >
+          {bodyChildren.map((el) => renderElement(el, el.id))}
+        </div>
+      );
+    }
+
+    // body가 없으면 루트 요소들 렌더링
+    const rootElements = elements
+      .filter((el) => !el.parent_id)
+      .sort((a, b) => (a.order_num || 0) - (b.order_num || 0));
+
+    return rootElements.map((el) => renderElement(el, el.id));
+  }, [elements, renderElement]);
+
+  return (
+    <div
+      className="preview-container"
+      onClick={handleClick}
+      style={{ width: '100%', height: '100%' }}
+    >
+      {elements.length === 0 ? (
+        <div className="preview-empty">No elements available</div>
+      ) : (
+        renderElementsTree()
+      )}
+    </div>
+  );
+}
+
+// ============================================
+// Preview App Component
+// ============================================
+
+export function PreviewApp() {
+  const [isInitialized, setIsInitialized] = useState(false);
+  const messageHandlerRef = useRef<MessageHandler | null>(null);
+
+  // 스토어에서 필요한 함수들 가져오기
+  const store = getPreviewStore();
+
+  // MessageHandler 초기화
+  useEffect(() => {
+    const storeState = store.getState();
+
+    messageHandlerRef.current = new MessageHandler({
+      setElements: storeState.setElements,
+      updateElementProps: storeState.updateElementProps,
+      setThemeVars: storeState.setThemeVars,
+      setDarkMode: storeState.setDarkMode,
+      setCurrentPageId: storeState.setCurrentPageId,
+      setCurrentLayoutId: storeState.setCurrentLayoutId,
+      setPages: storeState.setPages,
+      setDataSources: storeState.setDataSources,
+      setAuthToken: storeState.setAuthToken,
+      setReady: storeState.setReady,
+    });
+
+    // postMessage 리스너 등록
+    const handleMessage = (event: MessageEvent) => {
+      messageHandlerRef.current?.handle(event);
+    };
+
+    window.addEventListener('message', handleMessage);
+
+    // Preview 준비 완료 알림
+    messageSender.sendReady();
+    setIsInitialized(true);
+
+    console.log('[PreviewApp] Initialized and ready');
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [store]);
+
+  // 렌더링 함수 (PreviewRouter에 전달)
+  const renderElements = useCallback(() => {
+    return <PreviewContent />;
+  }, []);
+
+  if (!isInitialized) {
+    return (
+      <div className="preview-loading">
+        Initializing Preview...
+      </div>
+    );
+  }
+
+  return (
+    <PreviewRouter renderElements={renderElements}>
+      {/* 추가 오버레이나 UI 요소는 여기에 */}
+    </PreviewRouter>
+  );
+}
+
+export default PreviewApp;

--- a/src/preview-runtime/index.tsx
+++ b/src/preview-runtime/index.tsx
@@ -1,0 +1,127 @@
+/**
+ * Preview Runtime Entry Point
+ *
+ * srcdoc iframe 내에서 독립적으로 실행되는 Preview Runtime의 진입점입니다.
+ * Builder의 main.tsx와 완전히 분리된 별도의 React 앱입니다.
+ */
+
+import { createRoot } from 'react-dom/client';
+import { PreviewApp } from './PreviewApp';
+
+// ============================================
+// Styles (인라인으로 포함되거나 별도 CSS 파일)
+// ============================================
+
+const injectBaseStyles = () => {
+  const style = document.createElement('style');
+  style.id = 'preview-base-styles';
+  style.textContent = `
+    * {
+      box-sizing: border-box;
+    }
+
+    html, body, #preview-root {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+      line-height: 1.5;
+      color: var(--text-color, #1a1a1a);
+      background: var(--background-color, #ffffff);
+    }
+
+    .preview-container {
+      width: 100%;
+      min-height: 100%;
+    }
+
+    .preview-body {
+      width: 100%;
+      min-height: 100%;
+    }
+
+    .preview-empty {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      color: #999;
+      font-size: 14px;
+    }
+
+    .preview-loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      color: #666;
+      font-size: 14px;
+    }
+
+    /* Lasso Selection Box */
+    .lasso-selection-box {
+      position: fixed;
+      border: 2px dashed var(--action-primary-bg, #3b82f6);
+      background: rgba(59, 130, 246, 0.1);
+      pointer-events: none;
+      z-index: 9999;
+    }
+
+    /* Slot Container */
+    .slot-container {
+      min-height: 40px;
+    }
+  `;
+  document.head.appendChild(style);
+};
+
+// ============================================
+// Initialize Preview Runtime
+// ============================================
+
+function initPreviewRuntime() {
+  // 기본 스타일 주입
+  injectBaseStyles();
+
+  // Preview 마커 설정
+  document.body.setAttribute('data-preview', 'true');
+  document.body.setAttribute('data-preview-runtime', 'true');
+
+  // Root 엘리먼트 찾기 또는 생성
+  let root = document.getElementById('preview-root');
+
+  if (!root) {
+    root = document.createElement('div');
+    root.id = 'preview-root';
+    document.body.appendChild(root);
+  }
+
+  // React 앱 렌더링
+  const reactRoot = createRoot(root);
+  reactRoot.render(<PreviewApp />);
+
+  console.log('[Preview Runtime] Initialized');
+}
+
+// ============================================
+// Auto-initialize when DOM is ready
+// ============================================
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initPreviewRuntime);
+} else {
+  initPreviewRuntime();
+}
+
+// ============================================
+// Exports (번들 시 사용)
+// ============================================
+
+export { PreviewApp } from './PreviewApp';
+export { getPreviewStore, usePreviewStore } from './store';
+export { navigateInPreview } from './router';
+export { messageSender } from './messaging';

--- a/src/preview-runtime/messaging/index.ts
+++ b/src/preview-runtime/messaging/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Preview Messaging Exports
+ */
+
+export * from './messageHandler';

--- a/src/preview-runtime/messaging/messageHandler.ts
+++ b/src/preview-runtime/messaging/messageHandler.ts
@@ -1,0 +1,343 @@
+/**
+ * Message Handler - postMessage 수신 처리
+ *
+ * Builder로부터 전달받는 메시지를 처리합니다.
+ * Preview Runtime은 이 핸들러를 통해서만 데이터를 수신합니다.
+ */
+
+import type { PreviewStoreState, PreviewElement, PreviewPage, ThemeVar, DataSource } from '../store/types';
+
+// ============================================
+// Message Types (Builder → Preview)
+// ============================================
+
+export interface UpdateElementsMessage {
+  type: 'UPDATE_ELEMENTS';
+  elements: PreviewElement[];
+}
+
+export interface UpdateElementPropsMessage {
+  type: 'UPDATE_ELEMENT_PROPS';
+  elementId: string;
+  props: Record<string, unknown>;
+}
+
+export interface DeleteElementMessage {
+  type: 'DELETE_ELEMENT';
+  elementId: string;
+}
+
+export interface DeleteElementsMessage {
+  type: 'DELETE_ELEMENTS';
+  elementIds: string[];
+}
+
+export interface ThemeVarsMessage {
+  type: 'THEME_VARS';
+  vars: ThemeVar[];
+}
+
+export interface SetDarkModeMessage {
+  type: 'SET_DARK_MODE';
+  isDark: boolean;
+}
+
+export interface UpdatePageInfoMessage {
+  type: 'UPDATE_PAGE_INFO';
+  pageId: string | null;
+  layoutId: string | null;
+}
+
+export interface UpdatePagesMessage {
+  type: 'UPDATE_PAGES';
+  pages: PreviewPage[];
+}
+
+export interface UpdateDataSourcesMessage {
+  type: 'UPDATE_DATA_SOURCES';
+  dataSources: DataSource[];
+}
+
+export interface UpdateAuthContextMessage {
+  type: 'UPDATE_AUTH_CONTEXT';
+  token: string | null;
+}
+
+export interface RequestElementSelectionMessage {
+  type: 'REQUEST_ELEMENT_SELECTION';
+  elementId: string;
+}
+
+export type BuilderToPreviewMessage =
+  | UpdateElementsMessage
+  | UpdateElementPropsMessage
+  | DeleteElementMessage
+  | DeleteElementsMessage
+  | ThemeVarsMessage
+  | SetDarkModeMessage
+  | UpdatePageInfoMessage
+  | UpdatePagesMessage
+  | UpdateDataSourcesMessage
+  | UpdateAuthContextMessage
+  | RequestElementSelectionMessage;
+
+// ============================================
+// Message Handler Class
+// ============================================
+
+type StoreActions = Pick<
+  PreviewStoreState,
+  | 'setElements'
+  | 'updateElementProps'
+  | 'setThemeVars'
+  | 'setDarkMode'
+  | 'setCurrentPageId'
+  | 'setCurrentLayoutId'
+  | 'setPages'
+  | 'setDataSources'
+  | 'setAuthToken'
+  | 'setReady'
+>;
+
+export class MessageHandler {
+  private store: StoreActions;
+  private onElementSelected?: (elementId: string) => void;
+
+  constructor(
+    store: StoreActions,
+    options?: {
+      onElementSelected?: (elementId: string) => void;
+    }
+  ) {
+    this.store = store;
+    this.onElementSelected = options?.onElementSelected;
+  }
+
+  /**
+   * 메시지 이벤트 처리
+   */
+  handle(event: MessageEvent): void {
+    // Origin 검증 (production에서만)
+    if (import.meta.env.PROD) {
+      if (event.origin !== window.location.origin) {
+        console.warn('[Preview] Message from untrusted origin:', event.origin);
+        return;
+      }
+    }
+
+    const data = event.data as BuilderToPreviewMessage;
+    if (!data || typeof data !== 'object' || !data.type) {
+      return;
+    }
+
+    switch (data.type) {
+      case 'UPDATE_ELEMENTS':
+        this.handleUpdateElements(data);
+        break;
+
+      case 'UPDATE_ELEMENT_PROPS':
+        this.handleUpdateElementProps(data);
+        break;
+
+      case 'DELETE_ELEMENT':
+        this.handleDeleteElement(data);
+        break;
+
+      case 'DELETE_ELEMENTS':
+        this.handleDeleteElements(data);
+        break;
+
+      case 'THEME_VARS':
+        this.handleThemeVars(data);
+        break;
+
+      case 'SET_DARK_MODE':
+        this.handleSetDarkMode(data);
+        break;
+
+      case 'UPDATE_PAGE_INFO':
+        this.handleUpdatePageInfo(data);
+        break;
+
+      case 'UPDATE_PAGES':
+        this.handleUpdatePages(data);
+        break;
+
+      case 'UPDATE_DATA_SOURCES':
+        this.handleUpdateDataSources(data);
+        break;
+
+      case 'UPDATE_AUTH_CONTEXT':
+        this.handleUpdateAuthContext(data);
+        break;
+
+      case 'REQUEST_ELEMENT_SELECTION':
+        this.handleRequestElementSelection(data);
+        break;
+
+      default:
+        // 알 수 없는 메시지 타입은 무시
+        break;
+    }
+  }
+
+  // ============================================
+  // Individual Message Handlers
+  // ============================================
+
+  private handleUpdateElements(data: UpdateElementsMessage): void {
+    const elements = data.elements || [];
+    this.store.setElements(elements);
+
+    // ACK 전송
+    this.sendToBuilder({ type: 'ELEMENTS_UPDATED_ACK' });
+
+    console.log(`[Preview] Elements updated: ${elements.length} elements`);
+  }
+
+  private handleUpdateElementProps(data: UpdateElementPropsMessage): void {
+    const { elementId, props } = data;
+    if (elementId && props) {
+      this.store.updateElementProps(elementId, props);
+    }
+  }
+
+  private handleDeleteElement(data: DeleteElementMessage): void {
+    // setElements를 통해 필터링하여 삭제
+    // 실제 구현에서는 store에 deleteElement 메서드 추가 필요
+    console.log('[Preview] Delete element:', data.elementId);
+  }
+
+  private handleDeleteElements(data: DeleteElementsMessage): void {
+    console.log('[Preview] Delete elements:', data.elementIds);
+  }
+
+  private handleThemeVars(data: ThemeVarsMessage): void {
+    const vars = data.vars || [];
+    this.store.setThemeVars(vars);
+    console.log(`[Preview] Theme vars updated: ${vars.length} variables`);
+  }
+
+  private handleSetDarkMode(data: SetDarkModeMessage): void {
+    this.store.setDarkMode(data.isDark);
+    console.log(`[Preview] Dark mode: ${data.isDark}`);
+  }
+
+  private handleUpdatePageInfo(data: UpdatePageInfoMessage): void {
+    this.store.setCurrentPageId(data.pageId);
+    this.store.setCurrentLayoutId(data.layoutId);
+    console.log(`[Preview] Page info: pageId=${data.pageId}, layoutId=${data.layoutId}`);
+  }
+
+  private handleUpdatePages(data: UpdatePagesMessage): void {
+    const pages = data.pages || [];
+    this.store.setPages(pages);
+    console.log(`[Preview] Pages updated: ${pages.length} pages`);
+  }
+
+  private handleUpdateDataSources(data: UpdateDataSourcesMessage): void {
+    const dataSources = data.dataSources || [];
+    this.store.setDataSources(dataSources);
+    console.log(`[Preview] Data sources updated: ${dataSources.length} sources`);
+  }
+
+  private handleUpdateAuthContext(data: UpdateAuthContextMessage): void {
+    this.store.setAuthToken(data.token);
+    console.log('[Preview] Auth context updated');
+  }
+
+  private handleRequestElementSelection(data: RequestElementSelectionMessage): void {
+    if (this.onElementSelected) {
+      this.onElementSelected(data.elementId);
+    }
+  }
+
+  // ============================================
+  // Send to Builder
+  // ============================================
+
+  private sendToBuilder(message: Record<string, unknown>): void {
+    try {
+      window.parent.postMessage(message, window.location.origin);
+    } catch (error) {
+      console.error('[Preview] Failed to send message to builder:', error);
+    }
+  }
+}
+
+// ============================================
+// Message Sender (Preview → Builder)
+// ============================================
+
+export const messageSender = {
+  /**
+   * Preview 준비 완료 알림
+   */
+  sendReady(): void {
+    window.parent.postMessage({ type: 'PREVIEW_READY' }, '*');
+  },
+
+  /**
+   * 요소 선택 알림
+   */
+  sendElementSelected(
+    elementId: string,
+    rect: { top: number; left: number; width: number; height: number },
+    options?: { isMultiSelect?: boolean; props?: Record<string, unknown>; style?: Record<string, unknown> }
+  ): void {
+    window.parent.postMessage(
+      {
+        type: 'ELEMENT_SELECTED',
+        elementId,
+        isMultiSelect: options?.isMultiSelect || false,
+        payload: {
+          rect,
+          props: options?.props,
+          style: options?.style,
+        },
+      },
+      window.location.origin
+    );
+  },
+
+  /**
+   * Computed Style 전송
+   */
+  sendComputedStyle(elementId: string, computedStyle: Record<string, string>): void {
+    window.parent.postMessage(
+      {
+        type: 'ELEMENT_COMPUTED_STYLE',
+        elementId,
+        payload: { computedStyle },
+      },
+      window.location.origin
+    );
+  },
+
+  /**
+   * Lasso 선택 결과 전송
+   */
+  sendDragSelected(elementIds: string[]): void {
+    window.parent.postMessage(
+      {
+        type: 'ELEMENTS_DRAG_SELECTED',
+        elementIds,
+      },
+      window.location.origin
+    );
+  },
+
+  /**
+   * 상태 변경 알림 (디버깅용)
+   */
+  sendStateChanged(path: string, value: unknown): void {
+    window.parent.postMessage(
+      {
+        type: 'STATE_CHANGED',
+        path,
+        value,
+      },
+      window.location.origin
+    );
+  },
+};

--- a/src/preview-runtime/router/PreviewRouter.tsx
+++ b/src/preview-runtime/router/PreviewRouter.tsx
@@ -1,0 +1,182 @@
+/**
+ * Preview Router - MemoryRouter 기반 내부 라우팅
+ *
+ * Preview Runtime 내에서 독립적인 라우팅을 처리합니다.
+ * Builder의 BrowserRouter와 완전히 분리되어 동작합니다.
+ */
+
+import React, { useEffect, useRef } from 'react';
+import {
+  MemoryRouter,
+  Routes,
+  Route,
+  useNavigate,
+  useLocation,
+  type NavigateFunction,
+} from 'react-router-dom';
+import { usePreviewStore } from '../store';
+import type { PreviewPage } from '../store/types';
+
+// ============================================
+// Router Context (navigate 함수 공유용)
+// ============================================
+
+interface RouterContextValue {
+  navigate: NavigateFunction | null;
+}
+
+const RouterContext = React.createContext<RouterContextValue>({ navigate: null });
+
+export function usePreviewNavigate() {
+  const ctx = React.useContext(RouterContext);
+  return ctx.navigate;
+}
+
+// ============================================
+// Page Renderer Component
+// ============================================
+
+interface PageRendererProps {
+  pageId: string;
+  renderElements: () => React.ReactNode;
+}
+
+function PageRenderer({ pageId, renderElements }: PageRendererProps) {
+  const setCurrentPageId = usePreviewStore((s) => s.setCurrentPageId);
+
+  useEffect(() => {
+    setCurrentPageId(pageId);
+  }, [pageId, setCurrentPageId]);
+
+  return <>{renderElements()}</>;
+}
+
+// ============================================
+// Not Found Component
+// ============================================
+
+function NotFound() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100%',
+        padding: '2rem',
+        textAlign: 'center',
+      }}
+    >
+      <h1 style={{ fontSize: '2rem', marginBottom: '1rem' }}>404</h1>
+      <p style={{ color: '#666' }}>Page not found</p>
+    </div>
+  );
+}
+
+// ============================================
+// Router Navigator (navigate 함수 추출용)
+// ============================================
+
+interface RouterNavigatorProps {
+  onNavigateReady: (navigate: NavigateFunction) => void;
+}
+
+function RouterNavigator({ onNavigateReady }: RouterNavigatorProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const setCurrentPath = usePreviewStore((s) => s.setCurrentPath);
+
+  useEffect(() => {
+    onNavigateReady(navigate);
+  }, [navigate, onNavigateReady]);
+
+  // 경로 변경 시 스토어 업데이트
+  useEffect(() => {
+    setCurrentPath(location.pathname);
+  }, [location.pathname, setCurrentPath]);
+
+  return null;
+}
+
+// ============================================
+// Preview Router Component
+// ============================================
+
+interface PreviewRouterProps {
+  renderElements: () => React.ReactNode;
+  children?: React.ReactNode;
+}
+
+export function PreviewRouter({ renderElements, children }: PreviewRouterProps) {
+  const pages = usePreviewStore((s) => s.pages);
+  const currentPath = usePreviewStore((s) => s.currentPath);
+  const navigateRef = useRef<NavigateFunction | null>(null);
+
+  const handleNavigateReady = React.useCallback((nav: NavigateFunction) => {
+    navigateRef.current = nav;
+  }, []);
+
+  // 초기 경로 설정
+  const initialEntries = [currentPath || '/'];
+
+  return (
+    <RouterContext.Provider value={{ navigate: navigateRef.current }}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <RouterNavigator onNavigateReady={handleNavigateReady} />
+        <Routes>
+          {/* 동적으로 페이지 라우트 생성 */}
+          {pages.map((page: PreviewPage) => (
+            <Route
+              key={page.id}
+              path={page.slug || '/'}
+              element={
+                <PageRenderer pageId={page.id} renderElements={renderElements} />
+              }
+            />
+          ))}
+
+          {/* 페이지가 없을 때 기본 라우트 */}
+          {pages.length === 0 && (
+            <Route
+              path="/"
+              element={<>{renderElements()}</>}
+            />
+          )}
+
+          {/* 404 페이지 */}
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+        {children}
+      </MemoryRouter>
+    </RouterContext.Provider>
+  );
+}
+
+// ============================================
+// Navigation Helper (EventEngine에서 사용)
+// ============================================
+
+let globalNavigate: NavigateFunction | null = null;
+
+export function setGlobalNavigate(navigate: NavigateFunction) {
+  globalNavigate = navigate;
+}
+
+export function getGlobalNavigate(): NavigateFunction | null {
+  return globalNavigate;
+}
+
+/**
+ * Preview 내부에서 네비게이션 수행
+ * EventEngine에서 호출됩니다.
+ */
+export function navigateInPreview(path: string, options?: { replace?: boolean }) {
+  if (globalNavigate) {
+    globalNavigate(path, options);
+    return true;
+  }
+
+  console.warn('[PreviewRouter] Navigate function not available yet');
+  return false;
+}

--- a/src/preview-runtime/router/index.ts
+++ b/src/preview-runtime/router/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Preview Router Exports
+ */
+
+export * from './PreviewRouter';

--- a/src/preview-runtime/store/index.ts
+++ b/src/preview-runtime/store/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Preview Store Exports
+ */
+
+export * from './types';
+export * from './previewStore';

--- a/src/preview-runtime/store/previewStore.ts
+++ b/src/preview-runtime/store/previewStore.ts
@@ -1,0 +1,247 @@
+/**
+ * Preview Store - 독립 Zustand 스토어
+ *
+ * Builder와 완전히 분리된 상태 관리.
+ * postMessage를 통해서만 데이터를 수신합니다.
+ */
+
+import { create } from 'zustand';
+import type { PreviewStoreState, PreviewElement, PreviewPage, ThemeVar, DataSource, DataState } from './types';
+
+export const createPreviewStore = () => create<PreviewStoreState>((set, get) => ({
+  // ============================================
+  // Elements
+  // ============================================
+  elements: [],
+  setElements: (elements: PreviewElement[]) => set({ elements }),
+  updateElementProps: (id: string, props: Record<string, unknown>) => {
+    set((state) => ({
+      elements: state.elements.map((el) =>
+        el.id === id ? { ...el, props: { ...el.props, ...props } } : el
+      ),
+    }));
+  },
+
+  // ============================================
+  // Pages
+  // ============================================
+  pages: [],
+  setPages: (pages: PreviewPage[]) => set({ pages }),
+  currentPageId: null,
+  setCurrentPageId: (pageId: string | null) => set({ currentPageId: pageId }),
+  currentPath: '/',
+  setCurrentPath: (path: string) => set({ currentPath: path }),
+
+  // ============================================
+  // Layout
+  // ============================================
+  currentLayoutId: null,
+  setCurrentLayoutId: (layoutId: string | null) => set({ currentLayoutId: layoutId }),
+
+  // ============================================
+  // Theme
+  // ============================================
+  themeVars: [],
+  setThemeVars: (vars: ThemeVar[]) => {
+    set({ themeVars: vars });
+    // CSS 변수 적용
+    applyThemeVars(vars, get().isDarkMode);
+  },
+  isDarkMode: false,
+  setDarkMode: (isDark: boolean) => {
+    set({ isDarkMode: isDark });
+    document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
+    // 테마 변수 재적용
+    applyThemeVars(get().themeVars, isDark);
+  },
+
+  // ============================================
+  // Data Sources
+  // ============================================
+  dataSources: [],
+  setDataSources: (sources: DataSource[]) => set({ dataSources: sources }),
+  dataStates: new Map(),
+  setDataState: (sourceId: string, state: DataState) => {
+    set((prev) => {
+      const newDataStates = new Map(prev.dataStates);
+      newDataStates.set(sourceId, state);
+      return { dataStates: newDataStates };
+    });
+  },
+
+  // ============================================
+  // Auth Context
+  // ============================================
+  authToken: null,
+  setAuthToken: (token: string | null) => set({ authToken: token }),
+
+  // ============================================
+  // State Hierarchy
+  // ============================================
+  appState: {},
+  pageStates: new Map(),
+  componentStates: new Map(),
+
+  setState: (path: string, value: unknown) => {
+    const [scope, ...rest] = path.split('.');
+    const key = rest.join('.');
+
+    switch (scope) {
+      case 'app':
+        set((s) => ({ appState: { ...s.appState, [key]: value } }));
+        break;
+
+      case 'page': {
+        const pageId = get().currentPageId;
+        if (pageId) {
+          set((s) => {
+            const pageStates = new Map(s.pageStates);
+            const pageState = pageStates.get(pageId) || {};
+            pageStates.set(pageId, { ...pageState, [key]: value });
+            return { pageStates };
+          });
+        }
+        break;
+      }
+
+      case 'component': {
+        // elementId.propKey 형식
+        const dotIndex = key.indexOf('.');
+        if (dotIndex > 0) {
+          const elementId = key.slice(0, dotIndex);
+          const propKey = key.slice(dotIndex + 1);
+          set((s) => {
+            const componentStates = new Map(s.componentStates);
+            const componentState = componentStates.get(elementId) || {};
+            componentStates.set(elementId, { ...componentState, [propKey]: value });
+            return { componentStates };
+          });
+        }
+        break;
+      }
+
+      default:
+        // scope가 없으면 appState로 처리
+        set((s) => ({ appState: { ...s.appState, [path]: value } }));
+    }
+  },
+
+  getState: (path: string) => {
+    const [scope, ...rest] = path.split('.');
+    const key = rest.join('.');
+    const state = get();
+
+    switch (scope) {
+      case 'app':
+        return getNestedValue(state.appState, key);
+
+      case 'page':
+        return getNestedValue(state.pageStates.get(state.currentPageId || '') || {}, key);
+
+      case 'component': {
+        const dotIndex = key.indexOf('.');
+        if (dotIndex > 0) {
+          const elementId = key.slice(0, dotIndex);
+          const propKey = key.slice(dotIndex + 1);
+          return getNestedValue(state.componentStates.get(elementId) || {}, propKey);
+        }
+        return undefined;
+      }
+
+      default:
+        // scope가 없으면 appState에서 찾기
+        return getNestedValue(state.appState, path);
+    }
+  },
+
+  // ============================================
+  // Ready State
+  // ============================================
+  isReady: false,
+  setReady: (ready: boolean) => set({ isReady: ready }),
+}));
+
+// ============================================
+// Helper Functions
+// ============================================
+
+/**
+ * 중첩된 객체에서 값 가져오기
+ */
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  if (!path) return obj;
+
+  const keys = path.split('.');
+  let current: unknown = obj;
+
+  for (const key of keys) {
+    if (current === null || current === undefined) return undefined;
+    if (typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+
+  return current;
+}
+
+/**
+ * Theme 변수를 CSS 변수로 적용
+ */
+function applyThemeVars(vars: ThemeVar[], isDarkMode: boolean): void {
+  const root = document.documentElement;
+
+  // 기존 커스텀 스타일 제거
+  const existingStyle = document.getElementById('preview-theme-vars');
+  if (existingStyle) {
+    existingStyle.remove();
+  }
+
+  // 새 스타일 생성
+  const lightVars = vars.filter((v) => !v.isDark);
+  const darkVars = vars.filter((v) => v.isDark);
+
+  let cssText = ':root {\n';
+  lightVars.forEach((v) => {
+    cssText += `  ${v.name}: ${v.value};\n`;
+  });
+  cssText += '}\n';
+
+  if (darkVars.length > 0) {
+    cssText += '[data-theme="dark"] {\n';
+    darkVars.forEach((v) => {
+      cssText += `  ${v.name}: ${v.value};\n`;
+    });
+    cssText += '}\n';
+  }
+
+  const styleEl = document.createElement('style');
+  styleEl.id = 'preview-theme-vars';
+  styleEl.textContent = cssText;
+  document.head.appendChild(styleEl);
+
+  // 현재 테마 적용
+  root.setAttribute('data-theme', isDarkMode ? 'dark' : 'light');
+}
+
+// ============================================
+// Store Instance & Hooks
+// ============================================
+
+// 싱글톤 스토어 인스턴스
+let storeInstance: ReturnType<typeof createPreviewStore> | null = null;
+
+export function getPreviewStore() {
+  if (!storeInstance) {
+    storeInstance = createPreviewStore();
+  }
+  return storeInstance;
+}
+
+export function usePreviewStore<T>(selector: (state: PreviewStoreState) => T): T {
+  const store = getPreviewStore();
+  return store(selector);
+}
+
+// 전체 상태 접근 (non-React 환경용)
+export function getPreviewStoreState() {
+  return getPreviewStore().getState();
+}

--- a/src/preview-runtime/store/types.ts
+++ b/src/preview-runtime/store/types.ts
@@ -1,0 +1,120 @@
+/**
+ * Preview Runtime Store Types
+ *
+ * Preview Runtime은 Builder와 완전히 독립된 상태를 관리합니다.
+ * postMessage를 통해서만 데이터를 수신합니다.
+ */
+
+import type { CSSProperties } from 'react';
+
+// Element 타입 (Preview에서 사용하는 최소 타입)
+export interface PreviewElement {
+  id: string;
+  tag: string;
+  props: Record<string, unknown> & {
+    style?: CSSProperties;
+    className?: string;
+    children?: string;
+  };
+  parent_id: string | null;
+  page_id: string | null;
+  layout_id?: string | null;
+  order_num: number;
+  customId?: string;
+  dataBinding?: Record<string, unknown>;
+}
+
+// Page 타입
+export interface PreviewPage {
+  id: string;
+  title: string;
+  slug: string;
+  order_num: number;
+  layout_id?: string | null;
+}
+
+// Theme Variable 타입
+export interface ThemeVar {
+  name: string;
+  value: string;
+  isDark?: boolean;
+}
+
+// Data Source 타입
+export interface DataSource {
+  id: string;
+  name: string;
+  type: 'rest' | 'supabase' | 'static' | 'graphql';
+  url?: string;
+  method?: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  headers?: Record<string, string>;
+  body?: string;
+  table?: string;
+  filters?: Array<{ field: string; op: string; value: unknown }>;
+  realtime?: boolean;
+  data?: unknown;
+  transform?: string;
+  autoFetch?: 'onLoad' | 'manual';
+  cacheTTL?: number;
+}
+
+// Data State (loading, error, data)
+export interface DataState<T = unknown> {
+  loading: boolean;
+  error: string | null;
+  data: T | null;
+}
+
+// 상태 계층
+export interface StateHierarchy {
+  // App State (전역)
+  appState: Record<string, unknown>;
+  // Page State (페이지별)
+  pageStates: Map<string, Record<string, unknown>>;
+  // Component State (컴포넌트별)
+  componentStates: Map<string, Record<string, unknown>>;
+}
+
+// Preview Store State
+export interface PreviewStoreState extends StateHierarchy {
+  // Elements
+  elements: PreviewElement[];
+  setElements: (elements: PreviewElement[]) => void;
+  updateElementProps: (id: string, props: Record<string, unknown>) => void;
+
+  // Pages
+  pages: PreviewPage[];
+  setPages: (pages: PreviewPage[]) => void;
+  currentPageId: string | null;
+  setCurrentPageId: (pageId: string | null) => void;
+  currentPath: string;
+  setCurrentPath: (path: string) => void;
+
+  // Layout
+  currentLayoutId: string | null;
+  setCurrentLayoutId: (layoutId: string | null) => void;
+
+  // Theme
+  themeVars: ThemeVar[];
+  setThemeVars: (vars: ThemeVar[]) => void;
+  isDarkMode: boolean;
+  setDarkMode: (isDark: boolean) => void;
+
+  // Data Sources
+  dataSources: DataSource[];
+  setDataSources: (sources: DataSource[]) => void;
+  dataStates: Map<string, DataState>;
+  setDataState: (sourceId: string, state: DataState) => void;
+
+  // Auth Context
+  authToken: string | null;
+  setAuthToken: (token: string | null) => void;
+
+  // State Management
+  setState: (path: string, value: unknown) => void;
+  getState: (path: string) => unknown;
+
+  // Ready State
+  isReady: boolean;
+  setReady: (ready: boolean) => void;
+}

--- a/vite.preview.config.ts
+++ b/vite.preview.config.ts
@@ -1,0 +1,52 @@
+/**
+ * Vite Configuration for Preview Runtime
+ *
+ * Preview Runtime을 독립적인 번들로 빌드합니다.
+ * srcdoc iframe에 인라인으로 삽입될 JavaScript를 생성합니다.
+ */
+
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: "dist/preview-runtime",
+    emptyOutDir: true,
+    lib: {
+      entry: path.resolve(__dirname, "src/preview-runtime/index.tsx"),
+      name: "PreviewRuntime",
+      formats: ["iife"], // 즉시 실행 함수로 번들링 (srcdoc용)
+      fileName: () => "preview-runtime.js",
+    },
+    rollupOptions: {
+      // 모든 의존성을 번들에 포함
+      external: [],
+      output: {
+        // 전역 변수 설정 (필요 시)
+        globals: {},
+        // 인라인 CSS
+        assetFileNames: "preview-runtime.[ext]",
+      },
+    },
+    // 번들 최적화
+    minify: "terser",
+    terserOptions: {
+      compress: {
+        drop_console: false, // 개발 중에는 콘솔 유지
+      },
+    },
+    // 소스맵 (개발용)
+    sourcemap: false,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  define: {
+    // 환경 변수 정의
+    "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV || "production"),
+  },
+});


### PR DESCRIPTION
## Summary
- Preview Runtime을 독립된 srcdoc iframe으로 격리
- MemoryRouter로 내부 라우팅 처리 (부모 BrowserRouter와 분리)
- 독립 Zustand 스토어 (부모 스토어 폴백 없음)
- postMessage를 통한 데이터 동기화만 허용

## Changes
- `src/preview-runtime/` - 새로운 독립 Preview Runtime 모듈
- `vite.preview.config.ts` - 별도 빌드 설정
- `src/builder/main/previewSrcdoc.ts` - srcdoc HTML 생성
- `src/builder/main/BuilderWorkspace.tsx` - srcdoc 모드 지원

## Test plan
- [ ] `localStorage.setItem('USE_SRCDOC', 'true')` 후 빌더 테스트
- [ ] Preview 내 링크 클릭 시 iframe 내부에서만 동작 확인
- [ ] 요소 선택/편집 기능 정상 동작 확인
