### PR TITLE
fix: Use real <body> tag instead of fake body div

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -299,6 +298,7 @@
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -4599,7 +4599,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4992,7 +4993,6 @@
       "integrity": "sha512-p/jUvulfgU7oKtj6Xpk8cA2Y1xKTtICGpJYeJXz2YVO2UcvjQgeRMLDGfDeqeRW2Ta+0QNFwcc8X3GH8SxZz6w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5096,7 +5096,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -5345,7 +5344,6 @@
       "integrity": "sha512-irO+aGxYx/rAhjEBLsGPO4JQ8dA+A43enIST0j4xQ2kYHatHi9tUcxkRRGpClGuUVU42mi+iQsFFzd4xxpoV3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/mocker": "4.0.10",
         "@vitest/utils": "4.0.10",
@@ -5558,7 +5556,6 @@
       "integrity": "sha512-oWtNM89Np+YsQO3ttT5i1Aer/0xbzQzp66NzuJn/U16bB7MnvSzdLKXgk1kkMLYyKSSzA2ajzqMkYheaE9opuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.10",
         "fflate": "^0.8.2",
@@ -5613,7 +5610,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5850,7 +5846,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -6151,7 +6146,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6287,7 +6281,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6405,7 +6400,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6469,7 +6463,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7231,7 +7224,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -7845,6 +7837,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8374,7 +8367,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8470,6 +8462,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8485,6 +8478,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8528,7 +8522,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8665,7 +8658,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8678,7 +8670,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.9.6",
@@ -8875,7 +8868,6 @@
       "integrity": "sha512-MHngMYwGJVi6Fmnk6ISmnk7JAHRNF0UkuucA0CUW3N3a4KnONPEZz+vUanQP/ZC/iY1Qkf3bwPWzyY84wEks1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9055,7 +9047,6 @@
       "integrity": "sha512-vQMufKKA9TxgoEDHJv3esrqUkjszuuRiDkThiHxENFPdQawHhm2Dei+iwNRwH5W671zTDy9iRT9P1KDjcU5Iyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^1.6.0",
@@ -9312,7 +9303,6 @@
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
       "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
@@ -9341,8 +9331,7 @@
       "version": "4.1.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
       "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-react-aria-components": {
       "version": "2.0.1",
@@ -9522,7 +9511,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9662,7 +9650,6 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -9753,7 +9740,6 @@
       "integrity": "sha512-2Fqty3MM9CDwOVet/jaQalYlbcjATZwPYGcqpiYQqgQ/dLC7GuHdISKgTYIVF/kaishKxLzleKWWfbSDklyIKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.10",
         "@vitest/mocker": "4.0.10",
@@ -10061,7 +10047,6 @@
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/builder/main/previewSrcdoc.ts
+++ b/src/builder/main/previewSrcdoc.ts
@@ -21,8 +21,8 @@ const BASE_STYLES = `
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     line-height: 1.5;
   }
+  /* ⭐ 실제 <body> 태그가 element로 사용되므로 preview-body 클래스 불필요 */
   .preview-container { width: 100%; min-height: 100%; }
-  .preview-body { width: 100%; min-height: 100%; }
   .preview-empty, .preview-loading {
     display: flex;
     align-items: center;

--- a/src/builder/main/previewSrcdoc.ts
+++ b/src/builder/main/previewSrcdoc.ts
@@ -11,18 +11,17 @@
 
 const BASE_STYLES = `
   * { box-sizing: border-box; }
-  html, body, #preview-root {
+  html, body {
     margin: 0;
     padding: 0;
     width: 100%;
     height: 100%;
   }
+  /* ⭐ body가 React 루트이자 body element로 사용됨 (DOM/데이터 트리 일치) */
   body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     line-height: 1.5;
   }
-  /* ⭐ 실제 <body> 태그가 element로 사용되므로 preview-body 클래스 불필요 */
-  .preview-container { width: 100%; min-height: 100%; }
   .preview-empty, .preview-loading {
     display: flex;
     align-items: center;
@@ -47,6 +46,7 @@ const BASE_STYLES = `
 export function generateDevSrcdoc(projectId: string): string {
   // 개발 모드에서는 ESM import를 사용하여 HMR 지원
   // React Refresh preamble 전역 변수를 먼저 설정해야 함
+  // ⭐ React가 document.body에 직접 마운트됨 (DOM/데이터 트리 일치)
   return `
 <!DOCTYPE html>
 <html lang="ko">
@@ -57,9 +57,7 @@ export function generateDevSrcdoc(projectId: string): string {
   <style>${BASE_STYLES}</style>
 </head>
 <body data-preview="true" data-project-id="${projectId}">
-  <div id="preview-root">
-    <div class="preview-loading">Loading Preview Runtime...</div>
-  </div>
+  <div class="preview-loading">Loading Preview Runtime...</div>
   <script>
     // React Refresh preamble 전역 변수 설정 (모듈 로드 전에 필요)
     // @vitejs/plugin-react-swc가 이 변수들을 확인함
@@ -81,13 +79,13 @@ export function generateDevSrcdoc(projectId: string): string {
           console.warn('[Preview] React Refresh not available:', e.message);
         }
 
-        // 3. preview 로드
+        // 3. preview 로드 (React가 body에 직접 마운트됨)
         await import('/src/preview/index.tsx');
 
         console.log('[Preview] Runtime loaded successfully');
       } catch (err) {
         console.error('[Preview] Failed to load preview:', err);
-        document.getElementById('preview-root').innerHTML =
+        document.body.innerHTML =
           '<div class="preview-loading">Failed to load Preview Runtime: ' + err.message + '</div>';
       }
     }
@@ -126,6 +124,7 @@ export function generateProdSrcdoc(projectId: string): string {
     return generateDevSrcdoc(projectId);
   }
 
+  // ⭐ React가 document.body에 직접 마운트됨 (DOM/데이터 트리 일치)
   return `
 <!DOCTYPE html>
 <html lang="ko">
@@ -137,7 +136,6 @@ export function generateProdSrcdoc(projectId: string): string {
   ${previewCSS ? `<style>${previewCSS}</style>` : ''}
 </head>
 <body data-preview="true" data-project-id="${projectId}">
-  <div id="preview-root"></div>
   <script>${previewBundle}</script>
 </body>
 </html>

--- a/src/builder/overlay/index.tsx
+++ b/src/builder/overlay/index.tsx
@@ -63,23 +63,15 @@ export default function SelectionOverlay() {
         `[data-element-id="${selectedElementId}"]`
       ) as HTMLElement;
 
-      // ⭐ Layout/Slot System: Page body를 못 찾으면 Layout body로 대체
+      // ⭐ body element 선택 시: 실제 <body> 태그에서 찾기
+      // (실제 body에 data-element-id가 설정되어 있음)
       if (!element) {
         const selectedElement = elementsMap.get(selectedElementId);
-        // 선택된 요소가 Page의 body인 경우
-        if (selectedElement?.tag === 'body' && selectedElement?.page_id) {
-          // Layout body 찾기 (layout_id가 있는 body)
-          const layoutBody = Array.from(elementsMap.values()).find(el =>
-            el.tag === 'body' && el.layout_id && !el.page_id
-          );
-          if (layoutBody) {
-            element = iframe.contentDocument.querySelector(
-              `[data-element-id="${layoutBody.id}"]`
-            ) as HTMLElement;
-            console.log(`🔄 [Overlay] Page body → Layout body 대체:`, {
-              pageBodyId: selectedElementId,
-              layoutBodyId: layoutBody.id
-            });
+        if (selectedElement?.tag === 'body') {
+          // 실제 <body> 태그에서 찾기
+          if (iframe.contentDocument.body.getAttribute('data-element-id')) {
+            element = iframe.contentDocument.body;
+            console.log(`🔄 [Overlay] body element → 실제 <body> 태그 사용`);
           }
         }
       }
@@ -99,6 +91,7 @@ export default function SelectionOverlay() {
       };
 
       setOverlayRect(newRect);
+      // ⭐ body 태그 선택 시 'body' 표시
       setSelectedTag(element.tagName.toLowerCase());
     };
 
@@ -136,17 +129,13 @@ export default function SelectionOverlay() {
         `[data-element-id="${elementId}"]`
       ) as HTMLElement;
 
-      // ⭐ Layout/Slot System: Page body를 못 찾으면 Layout body로 대체
+      // ⭐ body element 선택 시: 실제 <body> 태그에서 찾기
       if (!element) {
         const selectedElement = elementsMap.get(elementId);
-        if (selectedElement?.tag === 'body' && selectedElement?.page_id) {
-          const layoutBody = Array.from(elementsMap.values()).find(el =>
-            el.tag === 'body' && el.layout_id && !el.page_id
-          );
-          if (layoutBody) {
-            element = iframe.contentDocument!.querySelector(
-              `[data-element-id="${layoutBody.id}"]`
-            ) as HTMLElement;
+        if (selectedElement?.tag === 'body') {
+          // 실제 <body> 태그에서 찾기
+          if (iframe.contentDocument!.body.getAttribute('data-element-id')) {
+            element = iframe.contentDocument!.body;
           }
         }
       }

--- a/src/builder/panels/ai/AIPanel.tsx
+++ b/src/builder/panels/ai/AIPanel.tsx
@@ -292,8 +292,8 @@ function AIPanelContent() {
               // Use selected element as parent
               parentId = selectedElementId;
             } else {
-              // Find Body element and use it as parent
-              const bodyElement = elements.find((el) => el.tag === "Body");
+              // Find body element and use it as parent
+              const bodyElement = elements.find((el) => el.tag === "body");
               if (bodyElement) {
                 parentId = bodyElement.id;
               }

--- a/src/preview/PreviewApp.tsx
+++ b/src/preview/PreviewApp.tsx
@@ -421,17 +421,16 @@ function PreviewContent() {
     return rootElements.map((el) => renderElement(el, el.id));
   }, [elements, renderElement, currentLayoutId, currentPageId, renderLayoutElement]);
 
+  // ⭐ React가 document.body에 직접 마운트되므로 preview-container 불필요
+  // body element의 자식들이 직접 <body> 안에 렌더링됨
   return (
-    <div
-      className="preview-container"
-      style={{ width: '100%', height: '100%' }}
-    >
+    <>
       {elements.length === 0 ? (
         <div className="preview-empty">No elements available</div>
       ) : (
         renderElementsTree()
       )}
-    </div>
+    </>
   );
 }
 

--- a/src/preview/index.tsx
+++ b/src/preview/index.tsx
@@ -23,28 +23,19 @@ const injectBaseStyles = () => {
       box-sizing: border-box;
     }
 
-    html, body, #preview-root {
+    html, body {
       margin: 0;
       padding: 0;
       width: 100%;
       height: 100%;
     }
 
+    /* ⭐ body가 React 루트이자 body element로 사용됨 */
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
       line-height: 1.5;
       color: var(--text-color, #1a1a1a);
       background: var(--background-color, #ffffff);
-    }
-
-    .preview-container {
-      width: 100%;
-      min-height: 100%;
-    }
-
-    .preview-body {
-      width: 100%;
-      min-height: 100%;
     }
 
     .preview-empty {
@@ -93,20 +84,14 @@ function initPreviewRuntime() {
   // Preview 마커 설정
   document.body.setAttribute('data-preview', 'true');
 
-  // Root 엘리먼트 찾기 또는 생성
-  let root = document.getElementById('preview-root');
-
-  if (!root) {
-    root = document.createElement('div');
-    root.id = 'preview-root';
-    document.body.appendChild(root);
-  }
-
-  // React 앱 렌더링
-  const reactRoot = createRoot(root);
+  // ⭐ 원천적 해결: React를 document.body에 직접 마운트
+  // - DOM 트리와 데이터 트리가 완벽히 일치
+  // - body element가 실제 <body> 태그와 1:1 매핑
+  // - 에디터 Overlay는 Builder 측(iframe 바깥)에서 처리되므로 충돌 없음
+  const reactRoot = createRoot(document.body);
   reactRoot.render(<PreviewApp />);
 
-  console.log('[Preview Runtime] Initialized');
+  console.log('[Preview Runtime] Initialized - React mounted directly on document.body');
 }
 
 // ============================================


### PR DESCRIPTION
- Remove duplicate body element by applying data-element-id directly to actual <body> tag
- Update PreviewApp to set body element attributes on document.body via useEffect
- Render only body children instead of wrapping in extra div
- Update click handler to capture body clicks on document level
- Update Overlay to find body element from actual <body> tag
- Handle Layout body and Page body consistently
- Remove preview-body class (no longer needed)

This eliminates the confusing "fake body" pattern where a div was used
to represent the body element, causing DOM structure issues.