### PR TITLE
refactor: Consolidate unit settings with global default unit

### DIFF
--- a/src/builder/panels/common/index.css
+++ b/src/builder/panels/common/index.css
@@ -531,6 +531,30 @@
            * 수정 불필요 - ComboBox.css와 동일한 변수명 */
         }
       }
+
+      /* ========================================
+       * PropertyUnitInput - Simplified unit input
+       * Global unit setting from Settings panel
+       * ======================================== */
+      .unit-input-wrapper {
+        position: relative;
+        display: flex;
+        align-items: center;
+        width: 100%;
+      }
+
+      .unit-input-wrapper .react-aria-Input {
+        padding-right: calc(var(--spacing-lg) + var(--spacing-sm));
+      }
+
+      .unit-suffix {
+        position: absolute;
+        right: var(--spacing-sm);
+        font-size: var(--text-xs);
+        color: var(--on-surface-variant);
+        pointer-events: none;
+        user-select: none;
+      }
     }
 
     .react-aria-control {

--- a/src/builder/panels/settings/SettingsPanel.tsx
+++ b/src/builder/panels/settings/SettingsPanel.tsx
@@ -19,6 +19,7 @@ import {
   Save,
   Moon,
   Sun,
+  CaseSensitive,
 } from "lucide-react";
 import { Button } from "react-aria-components";
 import { useParams } from "react-router-dom";
@@ -69,6 +70,9 @@ function SettingsContent() {
 
   const uiScale = useStore((state) => state.uiScale);
   const setUiScale = useStore((state) => state.setUiScale);
+
+  const defaultUnit = useStore((state) => state.defaultUnit);
+  const setDefaultUnit = useStore((state) => state.setDefaultUnit);
 
   // SaveMode 상태
   const isRealtimeMode = useStore((state) => state.isRealtimeMode);
@@ -138,9 +142,20 @@ function SettingsContent() {
     { value: "24", label: "24px" },
   ];
 
+  const defaultUnitOptions = [
+    { value: "px", label: "Pixels (px)" },
+    { value: "rem", label: "Root EM (rem)" },
+    { value: "em", label: "EM (em)" },
+    { value: "%", label: "Percent (%)" },
+  ];
+
   const handleGridSizeChange = (value: string) => {
     const size = parseInt(value) as 8 | 16 | 24;
     setGridSize(size);
+  };
+
+  const handleDefaultUnitChange = (value: string) => {
+    setDefaultUnit(value as 'px' | 'rem' | 'em' | '%');
   };
 
   const handleThemeModeChange = (value: string) => {
@@ -212,6 +227,17 @@ function SettingsContent() {
                 : `Save${pendingCount > 0 ? ` (${pendingCount})` : ""}`}
             </Button>
           )}
+        </PropertySection>
+
+        {/* Units Section */}
+        <PropertySection title="Units">
+          <PropertySelect
+            label="Default Unit"
+            value={defaultUnit}
+            onChange={handleDefaultUnitChange}
+            options={defaultUnitOptions}
+            icon={CaseSensitive}
+          />
         </PropertySection>
 
         {/* Preview & Overlay Section */}

--- a/src/builder/panels/styles/sections/AppearanceSection.tsx
+++ b/src/builder/panels/styles/sections/AppearanceSection.tsx
@@ -63,7 +63,6 @@ export function AppearanceSection({ selectedElement }: AppearanceSectionProps) {
           label="Border Width"
           className="border-width-control"
           value={getStyleValue(selectedElement, 'borderWidth', '0px')}
-          units={['reset', 'px']}
           onChange={(value) => updateStyle('borderWidth', value)}
           min={0}
           max={100}
@@ -73,7 +72,6 @@ export function AppearanceSection({ selectedElement }: AppearanceSectionProps) {
           label="Border Radius"
           className="border-radius-control"
           value={getStyleValue(selectedElement, 'borderRadius', '0px')}
-          units={['reset', 'px', '%', 'rem', 'em']}
           onChange={(value) => updateStyle('borderRadius', value)}
           min={0}
           max={500}

--- a/src/builder/panels/styles/sections/LayoutSection.tsx
+++ b/src/builder/panels/styles/sections/LayoutSection.tsx
@@ -240,7 +240,6 @@ export function LayoutSection({ selectedElement }: LayoutSectionProps) {
           icon={LayoutGrid}
           className="gap-control"
           value={getStyleValue(selectedElement, 'gap', '0px')}
-          units={['reset', 'px', 'rem', 'em']}
           onChange={(value) => updateStyle('gap', value)}
           min={0}
           max={500}
@@ -280,7 +279,6 @@ export function LayoutSection({ selectedElement }: LayoutSectionProps) {
               label={paddingValues.isMixed ? 'Padding (Mixed)' : 'Padding'}
               className="layout-padding"
               value={paddingValues.displayValue}
-              units={['reset', 'px', 'rem', 'em']}
               onChange={(value) => updateSpacingAll('padding', value)}
               min={0}
               max={500}
@@ -290,7 +288,6 @@ export function LayoutSection({ selectedElement }: LayoutSectionProps) {
               label={marginValues.isMixed ? 'Margin (Mixed)' : 'Margin'}
               className="layout-margin"
               value={marginValues.displayValue}
-              units={['reset', 'px', 'rem', 'em']}
               onChange={(value) => updateSpacingAll('margin', value)}
               min={0}
               max={500}
@@ -314,7 +311,6 @@ export function LayoutSection({ selectedElement }: LayoutSectionProps) {
                   label="T"
                   className="spacing-top"
                   value={paddingValues.top}
-                  units={['reset', 'px', 'rem', 'em']}
                   onChange={(value) => updateStyle('paddingTop', value)}
                   min={0}
                   max={500}
@@ -323,7 +319,6 @@ export function LayoutSection({ selectedElement }: LayoutSectionProps) {
                   label="R"
                   className="spacing-right"
                   value={paddingValues.right}
-                  units={['reset', 'px', 'rem', 'em']}
                   onChange={(value) => updateStyle('paddingRight', value)}
                   min={0}
                   max={500}
@@ -332,7 +327,6 @@ export function LayoutSection({ selectedElement }: LayoutSectionProps) {
                   label="B"
                   className="spacing-bottom"
                   value={paddingValues.bottom}
-                  units={['reset', 'px', 'rem', 'em']}
                   onChange={(value) => updateStyle('paddingBottom', value)}
                   min={0}
                   max={500}
@@ -341,7 +335,6 @@ export function LayoutSection({ selectedElement }: LayoutSectionProps) {
                   label="L"
                   className="spacing-left"
                   value={paddingValues.left}
-                  units={['reset', 'px', 'rem', 'em']}
                   onChange={(value) => updateStyle('paddingLeft', value)}
                   min={0}
                   max={500}
@@ -364,7 +357,6 @@ export function LayoutSection({ selectedElement }: LayoutSectionProps) {
                   label="T"
                   className="spacing-top"
                   value={marginValues.top}
-                  units={['reset', 'px', 'rem', 'em']}
                   onChange={(value) => updateStyle('marginTop', value)}
                   min={-500}
                   max={500}
@@ -373,7 +365,6 @@ export function LayoutSection({ selectedElement }: LayoutSectionProps) {
                   label="R"
                   className="spacing-right"
                   value={marginValues.right}
-                  units={['reset', 'px', 'rem', 'em']}
                   onChange={(value) => updateStyle('marginRight', value)}
                   min={-500}
                   max={500}
@@ -382,7 +373,6 @@ export function LayoutSection({ selectedElement }: LayoutSectionProps) {
                   label="B"
                   className="spacing-bottom"
                   value={marginValues.bottom}
-                  units={['reset', 'px', 'rem', 'em']}
                   onChange={(value) => updateStyle('marginBottom', value)}
                   min={-500}
                   max={500}
@@ -391,7 +381,6 @@ export function LayoutSection({ selectedElement }: LayoutSectionProps) {
                   label="L"
                   className="spacing-left"
                   value={marginValues.left}
-                  units={['reset', 'px', 'rem', 'em']}
                   onChange={(value) => updateStyle('marginLeft', value)}
                   min={-500}
                   max={500}

--- a/src/builder/panels/styles/sections/ModifiedStylesSection.tsx
+++ b/src/builder/panels/styles/sections/ModifiedStylesSection.tsx
@@ -118,7 +118,6 @@ export function ModifiedStylesSection({
         icon={RulerDimensionLine}
         label={formatLabel(property)}
         value={String(value)}
-        units={getUnitsForProperty(property)}
         onChange={(newValue) => updateStyle(property, newValue)}
         min={getMinForProperty(property)}
         max={getMaxForProperty(property)}
@@ -165,26 +164,6 @@ function formatLabel(property: string): string {
     .replace(/([A-Z])/g, ' $1')
     .replace(/^./, (str) => str.toUpperCase())
     .trim();
-}
-
-// Helper: Get units for property
-function getUnitsForProperty(property: string): string[] {
-  if (['width', 'height', 'top', 'left', 'right', 'bottom'].includes(property)) {
-    return ['reset', 'px', '%', 'rem', 'em', 'vh', 'vw'];
-  }
-  if (['padding', 'margin', 'gap'].includes(property)) {
-    return ['reset', 'px', 'rem', 'em'];
-  }
-  if (['fontSize', 'lineHeight', 'letterSpacing'].includes(property)) {
-    return ['reset', 'px', 'rem', 'em', 'pt'];
-  }
-  if (['borderWidth'].includes(property)) {
-    return ['reset', 'px'];
-  }
-  if (['borderRadius'].includes(property)) {
-    return ['reset', 'px', '%', 'rem', 'em'];
-  }
-  return ['px'];
 }
 
 // Helper: Get min value for property

--- a/src/builder/panels/styles/sections/TransformSection.tsx
+++ b/src/builder/panels/styles/sections/TransformSection.tsx
@@ -137,7 +137,6 @@ export function TransformSection({ selectedElement }: TransformSectionProps) {
           icon={RulerDimensionLine}
           label="Width"
           value={getStyleValue(selectedElement, 'width', 'auto')}
-          units={['reset', 'px', '%', 'rem', 'em', 'vh', 'vw']}
           onChange={(value) => updateStyle('width', value)}
           min={0}
           max={9999}
@@ -147,7 +146,6 @@ export function TransformSection({ selectedElement }: TransformSectionProps) {
           label="Height"
           className="transform-size-height"
           value={getStyleValue(selectedElement, 'height', 'auto')}
-          units={['reset', 'px', '%', 'rem', 'em', 'vh', 'vw']}
           onChange={(value) => updateStyle('height', value)}
           min={0}
           max={9999}
@@ -169,7 +167,6 @@ export function TransformSection({ selectedElement }: TransformSectionProps) {
           label="Left"
           className="transform-position-left"
           value={getStyleValue(selectedElement, 'left', 'auto')}
-          units={['reset', 'px', '%', 'rem', 'em', 'vh', 'vw']}
           onChange={(value) => updateStyle('left', value)}
           min={-9999}
           max={9999}
@@ -179,7 +176,6 @@ export function TransformSection({ selectedElement }: TransformSectionProps) {
           label="Top"
           className="transform-position-top"
           value={getStyleValue(selectedElement, 'top', 'auto')}
-          units={['reset', 'px', '%', 'rem', 'em', 'vh', 'vw']}
           onChange={(value) => updateStyle('top', value)}
           min={-9999}
           max={9999}

--- a/src/builder/panels/styles/sections/TypographySection.tsx
+++ b/src/builder/panels/styles/sections/TypographySection.tsx
@@ -82,7 +82,6 @@ export function TypographySection({ selectedElement }: TypographySectionProps) {
           icon={Type}
           label="Font Size"
           value={getStyleValue(selectedElement, 'fontSize', '16px')}
-          units={['reset', 'px', 'rem', 'em', 'pt']}
           onChange={(value) => updateStyle('fontSize', value)}
           min={8}
           max={200}
@@ -92,7 +91,6 @@ export function TypographySection({ selectedElement }: TypographySectionProps) {
           label="Line Height"
           className="text-size-height"
           value={getStyleValue(selectedElement, 'lineHeight', 'normal')}
-          units={['reset', 'px', 'rem', 'em', '']}
           onChange={(value) => updateStyle('lineHeight', value)}
           min={0}
           max={10}
@@ -135,7 +133,6 @@ export function TypographySection({ selectedElement }: TypographySectionProps) {
           label="Letter Spacing"
           className="text-weight-spacing-letter"
           value={getStyleValue(selectedElement, 'letterSpacing', 'normal')}
-          units={['reset', 'px', 'rem', 'em']}
           onChange={(value) => updateStyle('letterSpacing', value)}
           min={-10}
           max={10}

--- a/src/builder/stores/settings.ts
+++ b/src/builder/stores/settings.ts
@@ -11,6 +11,9 @@ export interface HistoryInfo {
  * Settings 상태 인터페이스
  * 빌더 환경 설정 관리
  */
+/** CSS 단위 타입 */
+export type CSSUnit = 'px' | 'rem' | 'em' | '%';
+
 export interface SettingsState {
   /** Selection Overlay 표시 여부 (기본값: true) */
   showOverlay: boolean;
@@ -38,6 +41,9 @@ export interface SettingsState {
 
   /** UI 스케일 (기본값: 100, 범위: 80 | 100 | 120) */
   uiScale: 80 | 100 | 120;
+
+  /** 기본 CSS 단위 (기본값: 'px') - 포토샵 스타일 전역 단위 설정 */
+  defaultUnit: CSSUnit;
 
   /** History 정보 (Monitor에서 사용) */
   historyInfo: HistoryInfo;
@@ -71,6 +77,9 @@ export interface SettingsState {
 
   /** History 정보 업데이트 */
   setHistoryInfo: (info: HistoryInfo) => void;
+
+  /** 기본 CSS 단위 설정 */
+  setDefaultUnit: (unit: CSSUnit) => void;
 }
 
 /**
@@ -86,6 +95,7 @@ export const createSettingsSlice: StateCreator<SettingsState> = (set) => ({
   overlayOpacity: 100,
   themeMode: 'auto',
   uiScale: 100,
+  defaultUnit: 'px',
   historyInfo: {
     canUndo: false,
     canRedo: false,
@@ -161,5 +171,12 @@ export const createSettingsSlice: StateCreator<SettingsState> = (set) => ({
    */
   setHistoryInfo: (info: HistoryInfo) => {
     set({ historyInfo: info });
+  },
+
+  /**
+   * 기본 CSS 단위 설정
+   */
+  setDefaultUnit: (unit: CSSUnit) => {
+    set({ defaultUnit: unit });
   },
 });


### PR DESCRIPTION
- Add defaultUnit setting to settings store (px, rem, em, %)
- Add Units section to SettingsPanel for global unit configuration
- Simplify PropertyUnitInput to use global defaultUnit instead of per-field dropdown
- Remove units prop from all style sections (Layout, Transform, Typography, Appearance, ModifiedStyles)
- Add unit-suffix display for visual feedback of current unit
- Reduce complexity by eliminating per-input unit selection

This follows the Photoshop-style approach where units are set globally rather than per input field, improving UX consistency and efficiency.