### PR TITLE
fix: Add dataset panel to DEFAULT_PANEL_LAYOUT leftPanels

### DIFF
--- a/src/builder/panels/core/types.ts
+++ b/src/builder/panels/core/types.ts
@@ -133,6 +133,7 @@ export const DEFAULT_PANEL_LAYOUT: PanelLayoutState = {
   leftPanels: [
     'nodes',
     'components',
+    'dataset',
     'theme',
     'ai',
     'settings',


### PR DESCRIPTION
DatasetPanel was registered in panelConfigs.ts but missing from
DEFAULT_PANEL_LAYOUT.leftPanels, causing it to not appear in the
left sidebar navigation.