### PR TITLE
Claude/fix lint typescript 01 c cg t mi rw9 uezu1jjda ug ee

### DIFF
--- a/src/builder/panels/dataset/presets/dataTablePresets.ts
+++ b/src/builder/panels/dataset/presets/dataTablePresets.ts
@@ -170,8 +170,7 @@ const generateCategories = (count: number): Record<string, unknown>[] =>
   }));
 
 const generateOrders = (count: number): Record<string, unknown>[] =>
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  Array.from({ length: count }, (_unused, i) => ({
+  Array.from({ length: count }, () => ({
     id: getRandomId("ord_"),
     userId: getRandomId("usr_"),
     items: Array.from({ length: randomInt(1, 5) }, () => ({
@@ -234,8 +233,7 @@ const generateAuditLogs = (count: number): Record<string, unknown>[] =>
   }));
 
 const generateProjectMemberships = (count: number): Record<string, unknown>[] =>
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  Array.from({ length: count }, (_unused, i) => ({
+  Array.from({ length: count }, () => ({
     id: getRandomId("mem_"),
     projectId: getRandomId("proj_"),
     userId: getRandomId("usr_"),

--- a/src/canvas/renderers/DataRenderers.tsx
+++ b/src/canvas/renderers/DataRenderers.tsx
@@ -232,8 +232,9 @@ function DatasetComponent({ element }: { element: PreviewElement }) {
  */
 export function renderDataset(
   element: PreviewElement,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _context: RenderContext
+  context: RenderContext
 ): React.ReactNode {
+  // context is required for rendererMap type consistency but not used in this renderer
+  void context;
   return <DatasetComponent key={element.id} element={element} />;
 }

--- a/src/shared/components/Table.tsx
+++ b/src/shared/components/Table.tsx
@@ -141,9 +141,7 @@ export default React.memo(function Table<T extends { id: string | number }>(
     size = 'md',
 
     dataBinding,
-    // columnMapping is destructured but reserved for future use
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    columnMapping,
+    // Note: columnMapping is available in props but not destructured until needed
 
     data: staticData,
     apiUrlKey,
@@ -173,12 +171,7 @@ export default React.memo(function Table<T extends { id: string | number }>(
   } = props;
 
   // useCollectionData Hook으로 데이터 가져오기 (PropertyDataBinding 형식 지원)
-  const {
-    data: boundData,
-    // loading is available for future use
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    loading: boundDataLoading,
-  } = useCollectionData({
+  const { data: boundData } = useCollectionData({
     dataBinding: dataBinding as DataBinding,
     componentName: "Table",
     fallbackData: [],


### PR DESCRIPTION
This pull request focuses on improving the handling of controlled and uncontrolled component patterns, especially for data binding and form fields in the builder panels. The main changes simplify state management by making components fully controlled where appropriate, resolve issues with input synchronization (notably for IME users), and refactor code for clarity and maintainability. There are also minor cleanups and improvements for mock data generation and renderer consistency.

**Form and Input Handling Improvements:**

* Refactored `PropertyDataBinding` to be a fully controlled component, removing internal `useState` and `useEffect` for `source`, `name`, and `path`, and updating handlers to call `onChange` immediately with new values. This ensures parent components always have the source of truth and fixes synchronization issues. [[1]](diffhunk://#diff-f6ee6f917e0b20e7ff964a541d6e865dbc232fb08955d2fce1871db9c78fe643L88-L103) [[2]](diffhunk://#diff-f6ee6f917e0b20e7ff964a541d6e865dbc232fb08955d2fce1871db9c78fe643L134-R130) [[3]](diffhunk://#diff-f6ee6f917e0b20e7ff964a541d6e865dbc232fb08955d2fce1871db9c78fe643R141-L201) [[4]](diffhunk://#diff-f6ee6f917e0b20e7ff964a541d6e865dbc232fb08955d2fce1871db9c78fe643L318-L322) [[5]](diffhunk://#diff-f6ee6f917e0b20e7ff964a541d6e865dbc232fb08955d2fce1871db9c78fe643L335-R299)
* Refactored the schema editor in `DataTableEditor` by splitting out a `SchemaFieldRow` component for each field. Each row now manages its own local state for `key` and `label`, which resolves IME input issues and improves code clarity. [[1]](diffhunk://#diff-fbc3b8971672f8ee05575c13d21c31d7a5aa751629c86967e7c4db07da25fd41L264-R296) [[2]](diffhunk://#diff-fbc3b8971672f8ee05575c13d21c31d7a5aa751629c86967e7c4db07da25fd41L348-R320) [[3]](diffhunk://#diff-fbc3b8971672f8ee05575c13d21c31d7a5aa751629c86967e7c4db07da25fd41R333-R362)
* Updated the cell editor in the mock data editor to use local state with a key prop for proper reset, further addressing IME issues. [[1]](diffhunk://#diff-fbc3b8971672f8ee05575c13d21c31d7a5aa751629c86967e7c4db07da25fd41R467-L484) [[2]](diffhunk://#diff-fbc3b8971672f8ee05575c13d21c31d7a5aa751629c86967e7c4db07da25fd41R423)

**Code Cleanup and Consistency:**

* Removed unused imports (`useEffect`) and commented-out code, and clarified comments regarding unused parameters for better code readability and maintainability. [[1]](diffhunk://#diff-f6ee6f917e0b20e7ff964a541d6e865dbc232fb08955d2fce1871db9c78fe643L19-R19) [[2]](diffhunk://#diff-fbc3b8971672f8ee05575c13d21c31d7a5aa751629c86967e7c4db07da25fd41L10-R10) [[3]](diffhunk://#diff-d19977f667c47ffb1508aee63e5a3e442ccfc20341707650fb0286d8c78144cfL144-R144) [[4]](diffhunk://#diff-d19977f667c47ffb1508aee63e5a3e442ccfc20341707650fb0286d8c78144cfL176-R174) [[5]](diffhunk://#diff-7de924a4557493a3bf456a0c95d5d9a5684408fe9b2c430b2f8dedc9dd63f5b4L235-R238)
* Cleaned up mock data generation functions by removing unused parameters and disabling unnecessary ESLint comments. [[1]](diffhunk://#diff-26d623c1cd28e9bd24cb0860abfe3d920798cf29ae7c53a469375af1343a6335L173-R173) [[2]](diffhunk://#diff-26d623c1cd28e9bd24cb0860abfe3d920798cf29ae7c53a469375af1343a6335L237-R236)