### PR TITLE
fix(adr-059): ProgressBar per-size label font + Meter forced-colors f…

### DIFF
--- a/packages/shared/src/components/styles/generated/Meter.css
+++ b/packages/shared/src/components/styles/generated/Meter.css
@@ -147,6 +147,7 @@
     background: var(--fill-color);
     height: 100%;
     transition: width 200ms ease-out;
+    forced-color-adjust: auto;
   }
 
 

--- a/packages/shared/src/components/styles/generated/ProgressBar.css
+++ b/packages/shared/src/components/styles/generated/ProgressBar.css
@@ -99,6 +99,22 @@
   pointer-events: none;
 }
 
+.react-aria-ProgressBar[data-size="sm"] {
+  --label-font-size: var(--text-xs);
+}
+
+.react-aria-ProgressBar[data-size="md"] {
+  --label-font-size: var(--text-sm);
+}
+
+.react-aria-ProgressBar[data-size="lg"] {
+  --label-font-size: var(--text-base);
+}
+
+.react-aria-ProgressBar[data-size="xl"] {
+  --label-font-size: var(--text-lg);
+}
+
 
 @media (forced-colors: active) {
   .react-aria-ProgressBar {

--- a/packages/specs/src/components/Meter.spec.ts
+++ b/packages/specs/src/components/Meter.spec.ts
@@ -353,6 +353,7 @@ export const MeterSpec: ComponentSpec<MeterProps> = {
         background: "var(--fill-color)",
         height: "100%",
         transition: "width 200ms ease-out",
+        "forced-color-adjust": "auto",
       },
     },
     containerVariants: {

--- a/packages/specs/src/components/ProgressBar.spec.ts
+++ b/packages/specs/src/components/ProgressBar.spec.ts
@@ -395,6 +395,12 @@ export const ProgressBarSpec: ComponentSpec<ProgressBarProps> = {
           },
         },
       },
+      size: {
+        sm: { styles: { "--label-font-size": "var(--text-xs)" } },
+        md: { styles: { "--label-font-size": "var(--text-sm)" } },
+        lg: { styles: { "--label-font-size": "var(--text-base)" } },
+        xl: { styles: { "--label-font-size": "var(--text-lg)" } },
+      },
     },
     sizeSelectors: {
       sm: {

--- a/packages/specs/src/renderers/__tests__/__snapshots__/CSSGenerator.snapshot.test.ts.snap
+++ b/packages/specs/src/renderers/__tests__/__snapshots__/CSSGenerator.snapshot.test.ts.snap
@@ -5031,6 +5031,7 @@ exports[`CSSGenerator snapshot baseline > Meter 1`] = `
     background: var(--fill-color);
     height: 100%;
     transition: width 200ms ease-out;
+    forced-color-adjust: auto;
   }
 
 
@@ -6180,6 +6181,22 @@ exports[`CSSGenerator snapshot baseline > ProgressBar 1`] = `
   opacity: 0.38;
   cursor: not-allowed;
   pointer-events: none;
+}
+
+.react-aria-ProgressBar[data-size="sm"] {
+  --label-font-size: var(--text-xs);
+}
+
+.react-aria-ProgressBar[data-size="md"] {
+  --label-font-size: var(--text-sm);
+}
+
+.react-aria-ProgressBar[data-size="lg"] {
+  --label-font-size: var(--text-base);
+}
+
+.react-aria-ProgressBar[data-size="xl"] {
+  --label-font-size: var(--text-lg);
 }
 
 


### PR DESCRIPTION
…ill accessibility

- ProgressBar.spec.ts: add containerVariants.size (sm/md/lg/xl) setting --label-font-size per data-size, mirroring Meter's existing pattern
- Meter.spec.ts: add forced-color-adjust: auto to staticSelectors[".fill"] to preserve high-contrast fill accessibility (path b: partial fix via forced-color-adjust since CSSGenerator has no @media nested selector emit)
- Regenerate generated/ProgressBar.css and generated/Meter.css
- Update CSSGenerator snapshot (2 snapshots: Meter + ProgressBar only)