### PR TITLE
debug(adr-903): P2 dev 로그 보강 — resolve 0 root cause 진단용

### DIFF
--- a/apps/builder/src/preview/App.tsx
+++ b/apps/builder/src/preview/App.tsx
@@ -154,6 +154,22 @@ function CanvasContent() {
       const refCount = doc.children.filter((c) => c.type === "ref").length;
       const reusableCount = doc.children.filter((c) => c.reusable).length;
 
+      // [DEBUG] resolver 가 빈 배열 반환하는 root cause 진단용 추가 출력.
+      // ADR-903 옵션 C 검증 후 제거.
+      const childrenSummary = doc.children.slice(0, 5).map((c) => ({
+        id: c.id,
+        type: c.type,
+        reusable: c.reusable ?? false,
+        metaType: (c.metadata as Record<string, unknown> | undefined)?.type,
+        metaPageId: (c.metadata as Record<string, unknown> | undefined)?.pageId,
+      }));
+      const resolvedSummary = resolved.slice(0, 5).map((n) => ({
+        id: n.id,
+        type: n.type,
+        metaType: (n.metadata as Record<string, unknown> | undefined)?.type,
+        metaPageId: (n.metadata as Record<string, unknown> | undefined)?.pageId,
+      }));
+
       console.log("[ADR-903 P2] canonical resolve", {
         input: {
           elements: elements.length,
@@ -167,9 +183,11 @@ function CanvasContent() {
           children: doc.children.length,
           reusables: reusableCount,
           refs: refCount,
+          childrenSummary, // [DEBUG] doc.children 처음 5개 구조
         },
         resolved: {
           rootCount: resolved.length,
+          summary: resolvedSummary, // [DEBUG] resolved 처음 5개 구조
         },
       });
     } catch (err) {


### PR DESCRIPTION
옵션 C 활성화 시 console "[ADR-903 옵션C] canonical 노드 없음 — legacy fallback {resolvedCount: 0}" 가 출력되는데, resolvedCount === 0 은 page filter 가 0 통과한 게 아니라 resolveCanonicalDocument 자체가 빈 배열 반환했다는 의미.

Team 1 fix (resolvers/canonical/index.ts metadata 보존) 는 page filter miss 가 원인이라는 가정 하에 작성됐으나 실제로는 resolver 단계가 0 → fix 가 root cause 미해결 가능성.

본 commit
- App.tsx:157 P2 dev 로그에 doc.children 처음 5개 + resolved 처음 5개 구조 출력
- childrenSummary: { id, type, reusable, metaType, metaPageId }
- resolvedSummary: { id, type, metaType, metaPageId }

검증 절차 (사용자)
1. 본 branch 머지 또는 fix branch 와 비교 머지
2. ?canonical=1 으로 builder 재접속
3. Console "[ADR-903 P2] canonical resolve" 객체 expand
4. document.children, resolved.summary 값으로 root cause 판정:
   - children = 0 → legacyToCanonical input 문제 (elements/pages/layouts 0)
   - children > 0, resolved.rootCount = 0 → resolver 가 모든 노드 throw + catch
   - children > 0, resolved.rootCount > 0 → page filter 단계 문제 (Team 1 가설 정합)

후속
- root cause 판정 후 본 commit revert + 정확한 fix 적용

검증
- type-check 3/3 PASS