### PR TITLE
feat(adr-910): Phase 1 — themes read-only snapshot adapter

### DIFF
--- a/apps/builder/src/adapters/canonical/__tests__/themes.test.ts
+++ b/apps/builder/src/adapters/canonical/__tests__/themes.test.ts
@@ -1,0 +1,236 @@
+/**
+ * @fileoverview ADR-910 Phase 1 — themes read-only snapshot adapter tests.
+ *
+ * Gate G-A 검증:
+ * - `snapshotThemesFromConfig()` pure function
+ * - `readCanonicalThemes()` read accessor
+ * - `legacyToCanonical()` + `getThemeConfig` 연동
+ * - stale snapshot 방지 (R4) 단위 테스트
+ * - 빈 ThemeConfig / dark mode / tint override 등
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  snapshotThemesFromConfig,
+  readCanonicalThemes,
+  type ThemeConfigInput,
+  type ThemeSnapshot,
+} from "../themesAdapter";
+import { legacyToCanonical } from "../index";
+import { convertComponentRole } from "../componentRoleAdapter";
+import { convertPageLayout } from "../slotAndLayoutAdapter";
+import type { CompositionDocument } from "@composition/shared";
+
+const deps = { convertComponentRole, convertPageLayout };
+
+// ─────────────────────────────────────────────
+// TC-T1: snapshotThemesFromConfig — 기본 변환
+// ─────────────────────────────────────────────
+describe("snapshotThemesFromConfig (ADR-910 Phase 1)", () => {
+  it("TC-T1: tint/darkMode/neutral/radiusScale 필드를 그대로 복사한다", () => {
+    const config: ThemeConfigInput = {
+      tint: "blue",
+      darkMode: "light",
+      neutral: "neutral",
+      radiusScale: "md",
+    };
+    const snapshot = snapshotThemesFromConfig(config);
+    expect(snapshot.tint).toBe("blue");
+    expect(snapshot.darkMode).toBe("light");
+    expect(snapshot.neutral).toBe("neutral");
+    expect(snapshot.radiusScale).toBe("md");
+  });
+
+  // ─────────────────────────────────────────────
+  // TC-T2: dark mode 시나리오
+  // ─────────────────────────────────────────────
+  it("TC-T2: darkMode=dark 를 snapshot 에 정확히 반영한다", () => {
+    const config: ThemeConfigInput = {
+      tint: "purple",
+      darkMode: "dark",
+      neutral: "slate",
+      radiusScale: "lg",
+    };
+    const snapshot = snapshotThemesFromConfig(config);
+    expect(snapshot.darkMode).toBe("dark");
+    expect(snapshot.tint).toBe("purple");
+  });
+
+  // ─────────────────────────────────────────────
+  // TC-T3: system dark mode preference
+  // ─────────────────────────────────────────────
+  it("TC-T3: darkMode=system 을 그대로 보존한다 (resolveSkiaTheme 는 소비자 책임)", () => {
+    const config: ThemeConfigInput = {
+      tint: "green",
+      darkMode: "system",
+      neutral: "neutral",
+      radiusScale: "sm",
+    };
+    const snapshot = snapshotThemesFromConfig(config);
+    expect(snapshot.darkMode).toBe("system");
+  });
+
+  // ─────────────────────────────────────────────
+  // TC-T4: customTokens 슬롯 — 기본 미포함 확인
+  // ─────────────────────────────────────────────
+  it("TC-T4: customTokens 필드는 기본적으로 undefined (미포함)", () => {
+    const config: ThemeConfigInput = {
+      tint: "blue",
+      darkMode: "light",
+      neutral: "neutral",
+      radiusScale: "md",
+    };
+    const snapshot = snapshotThemesFromConfig(config);
+    expect(snapshot.customTokens).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────
+// TC-T5: readCanonicalThemes — round-trip
+// ─────────────────────────────────────────────
+describe("readCanonicalThemes (ADR-910 Phase 1)", () => {
+  it("TC-T5: snapshot round-trip — snapshotThemesFromConfig → doc → readCanonicalThemes", () => {
+    const config: ThemeConfigInput = {
+      tint: "indigo",
+      darkMode: "dark",
+      neutral: "zinc",
+      radiusScale: "xl",
+    };
+    const snapshot = snapshotThemesFromConfig(config);
+
+    // CompositionDocument.themes 타입이 Record<string, string[]> stub 이므로
+    // cast 하여 주입 (실제 legacyToCanonical 내부와 동일 패턴)
+    const doc: CompositionDocument = {
+      version: "composition-1.0",
+      themes: snapshot as unknown as Record<string, string[]>,
+      children: [],
+    };
+
+    const result = readCanonicalThemes(doc);
+    expect(result).not.toBeUndefined();
+    expect(result?.tint).toBe("indigo");
+    expect(result?.darkMode).toBe("dark");
+    expect(result?.neutral).toBe("zinc");
+    expect(result?.radiusScale).toBe("xl");
+  });
+
+  it("themes 필드 없는 doc → readCanonicalThemes 는 undefined 반환", () => {
+    const doc: CompositionDocument = {
+      version: "composition-1.0",
+      children: [],
+    };
+    expect(readCanonicalThemes(doc)).toBeUndefined();
+  });
+
+  it("themes 에 ThemeSnapshot 구조가 아닌 값 → undefined 반환", () => {
+    // 기존 stub 형태 (Record<string, string[]>) 가 ThemeSnapshot 필드를 갖지 않으면 undefined
+    const doc: CompositionDocument = {
+      version: "composition-1.0",
+      themes: { mode: ["light", "dark"] } as Record<string, string[]>,
+      children: [],
+    };
+    // mode 필드만 있고 tint/darkMode/neutral/radiusScale 없음 → undefined
+    expect(readCanonicalThemes(doc)).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────
+// TC-T6: legacyToCanonical + getThemeConfig 연동
+// ─────────────────────────────────────────────
+describe("legacyToCanonical + getThemeConfig (ADR-910 Phase 1)", () => {
+  it("TC-T6: getThemeConfig 전달 시 doc.themes 에 snapshot 주입된다", () => {
+    const config: ThemeConfigInput = {
+      tint: "cyan",
+      darkMode: "light",
+      neutral: "neutral",
+      radiusScale: "none",
+    };
+
+    const doc = legacyToCanonical(
+      { elements: [], pages: [], layouts: [] },
+      { ...deps, getThemeConfig: () => config },
+    );
+
+    expect(doc.themes).toBeDefined();
+    const snapshot = readCanonicalThemes(doc);
+    expect(snapshot?.tint).toBe("cyan");
+    expect(snapshot?.darkMode).toBe("light");
+    expect(snapshot?.radiusScale).toBe("none");
+  });
+
+  it("TC-T7: getThemeConfig 미전달 시 doc.themes 는 undefined (BC 유지)", () => {
+    const doc = legacyToCanonical(
+      { elements: [], pages: [], layouts: [] },
+      deps,
+    );
+    expect(doc.themes).toBeUndefined();
+  });
+
+  it("TC-T8: getThemeConfig 는 call-time 호출 (R4 stale 방지) — 호출 횟수 1회 검증", () => {
+    let callCount = 0;
+    const config: ThemeConfigInput = {
+      tint: "red",
+      darkMode: "dark",
+      neutral: "neutral",
+      radiusScale: "sm",
+    };
+
+    legacyToCanonical(
+      { elements: [], pages: [], layouts: [] },
+      {
+        ...deps,
+        getThemeConfig: () => {
+          callCount++;
+          return config;
+        },
+      },
+    );
+
+    // legacyToCanonical 내에서 getThemeConfig 는 정확히 1회 호출되어야 한다
+    // (subscribe 기반이 아닌 call-time 직렬화)
+    expect(callCount).toBe(1);
+  });
+
+  it("TC-T9: tint override 시 snapshot 에 반영 — 변경된 값이 doc.themes 에 기록된다", () => {
+    const config: ThemeConfigInput = {
+      tint: "orange",
+      darkMode: "light",
+      neutral: "neutral",
+      radiusScale: "md",
+    };
+
+    const doc1 = legacyToCanonical(
+      { elements: [], pages: [], layouts: [] },
+      { ...deps, getThemeConfig: () => config },
+    );
+
+    // tint 변경 후 재직렬화
+    const updatedConfig: ThemeConfigInput = { ...config, tint: "pink" };
+    const doc2 = legacyToCanonical(
+      { elements: [], pages: [], layouts: [] },
+      { ...deps, getThemeConfig: () => updatedConfig },
+    );
+
+    const snap1 = readCanonicalThemes(doc1);
+    const snap2 = readCanonicalThemes(doc2);
+
+    expect(snap1?.tint).toBe("orange");
+    expect(snap2?.tint).toBe("pink");
+  });
+
+  it("TC-T10: doc.version 은 themes 주입 여부와 무관하게 composition-1.0 유지", () => {
+    const doc = legacyToCanonical(
+      { elements: [], pages: [], layouts: [] },
+      {
+        ...deps,
+        getThemeConfig: () => ({
+          tint: "blue",
+          darkMode: "light",
+          neutral: "neutral",
+          radiusScale: "md",
+        }),
+      },
+    );
+    expect(doc.version).toBe("composition-1.0");
+  });
+});

--- a/apps/builder/src/adapters/canonical/index.ts
+++ b/apps/builder/src/adapters/canonical/index.ts
@@ -43,6 +43,10 @@ import {
   buildSlotPathMap,
   legacyLayoutToCanonicalFrame,
 } from "./slotAndLayoutAdapter";
+import {
+  snapshotThemesFromConfig,
+  type ThemeConfigInput,
+} from "./themesAdapter";
 
 // ─────────────────────────────────────────────
 // P3-A 신규 타입 surface
@@ -86,6 +90,13 @@ export type CanonicalPageRef = RefNode & {
 export interface LegacyAdapterDeps {
   convertComponentRole: ConvertComponentRoleFn;
   convertPageLayout: ConvertPageLayoutFn;
+  /**
+   * ADR-910 Phase 1 — themes read-only snapshot 주입 (선택).
+   *
+   * 전달 시: `doc.themes = snapshotThemesFromConfig(getThemeConfig())` 주입.
+   * 미전달 시: `doc.themes = undefined` (BC — 기존 동작 유지).
+   */
+  getThemeConfig?: () => ThemeConfigInput;
 }
 
 export function legacyToCanonical(
@@ -93,7 +104,7 @@ export function legacyToCanonical(
   deps: LegacyAdapterDeps,
 ): CompositionDocument {
   const { elements, pages, layouts } = input;
-  const { convertComponentRole, convertPageLayout } = deps;
+  const { convertComponentRole, convertPageLayout, getThemeConfig } = deps;
 
   // 1. id path 컨텍스트 구축 (UUID → stable path remap)
   const idPathCtx = buildIdPathContext(elements);
@@ -213,8 +224,18 @@ export function legacyToCanonical(
     return convertLayoutToReusableFrame(layout, layoutElements);
   });
 
+  // ADR-910 Phase 1: themes read-only snapshot 주입 (opt-in)
+  // call-time 직렬화 — subscribe 기반 아님 (R4 대응: stale snapshot 방지)
+  const themesSnapshot = getThemeConfig
+    ? (snapshotThemesFromConfig(getThemeConfig()) as unknown as Record<
+        string,
+        string[]
+      >)
+    : undefined;
+
   return {
     version: "composition-1.0",
+    ...(themesSnapshot !== undefined ? { themes: themesSnapshot } : {}),
     children: [...layoutFrames, ...reusableMasters, ...pageNodes],
   };
 }

--- a/apps/builder/src/adapters/canonical/themesAdapter.ts
+++ b/apps/builder/src/adapters/canonical/themesAdapter.ts
@@ -1,0 +1,127 @@
+/**
+ * @fileoverview ADR-910 Phase 1 — Themes Read-Only Snapshot Adapter
+ *
+ * ADR-021 themeConfigStore 의 현재 상태를 canonical document `themes` 필드로
+ * 투영하는 read-only snapshot adapter.
+ *
+ * **Read-only 원칙**:
+ * - canonical document → themeConfigStore 쓰기 금지 (Phase 2 write-through 에서 구현)
+ * - 런타임 테마 변경은 여전히 themeConfigStore 가 SSOT
+ * - `snapshotThemesFromConfig()` 는 call-time 직렬화 — subscribe 기반 아님
+ *   (ADR-910 R4 대응: stale snapshot 방지)
+ *
+ * **ThemeSnapshot 설계 (ADR-910 R2)**:
+ * - `tint`, `darkMode`, `customTokens` 슬롯 예약으로 확장 가능
+ * - per-element theme override 는 후속 ADR 에서 결정
+ */
+
+import type { CompositionDocument } from "@composition/shared";
+
+// ─────────────────────────────────────────────
+// ThemeSnapshot — 확장 가능한 테마 스냅샷 타입
+// ─────────────────────────────────────────────
+
+/**
+ * canonical document `themes` 필드의 구체화된 snapshot 타입.
+ *
+ * ADR-910 R2 대응: `Record<string, string[]>` stub 대신 확장 가능한 구조체.
+ * - `tint`: 현재 Tint 프리셋 이름 (ADR-021 TintPreset)
+ * - `darkMode`: 현재 Dark mode 설정 ("light" | "dark" | "system")
+ * - `neutral`: 현재 Neutral 프리셋 이름 (ADR-021 NeutralPreset)
+ * - `radiusScale`: 현재 Border radius 스케일 ("none" | "sm" | "md" | "lg" | "xl")
+ * - `customTokens`: 향후 per-element override 확장용 슬롯 (현재 미사용)
+ */
+export interface ThemeSnapshot {
+  /** ADR-021 Tint 프리셋 ("blue" | "indigo" | "purple" | ...) */
+  tint: string;
+  /** ADR-021 Dark mode 설정 ("light" | "dark" | "system") */
+  darkMode: string;
+  /** ADR-021 Neutral 프리셋 */
+  neutral: string;
+  /** Border radius 스케일 */
+  radiusScale: string;
+  /** 향후 확장: per-element theme override, custom token map 등 */
+  customTokens?: Record<string, string>;
+}
+
+// ─────────────────────────────────────────────
+// ThemeConfig 최소 타입 (adapter DI 계약)
+// ─────────────────────────────────────────────
+
+/**
+ * adapter 가 필요로 하는 themeConfigStore 최소 인터페이스.
+ *
+ * 실제 `ThemeConfigState` (themeConfigStore.ts) 는 이 인터페이스의 슈퍼셋.
+ * 어댑터는 actions/themeVersion 등 런타임 전용 필드를 참조하지 않는다.
+ */
+export interface ThemeConfigInput {
+  tint: string;
+  darkMode: string;
+  neutral: string;
+  radiusScale: string;
+}
+
+// ─────────────────────────────────────────────
+// Core adapter functions
+// ─────────────────────────────────────────────
+
+/**
+ * themeConfigStore 현재 상태 → `ThemeSnapshot` 직렬화.
+ *
+ * call-time 직렬화 (subscribe 기반 아님) — stale snapshot 방지 (ADR-910 R4).
+ * `legacyToCanonical()` 호출 시 전달된 `getThemeConfig()` 콜백에서 호출됨.
+ *
+ * @param themeConfig - themeConfigStore 현재 상태 (ThemeConfigInput 최소 계약)
+ * @returns ThemeSnapshot — canonical document themes 필드에 주입할 snapshot
+ */
+export function snapshotThemesFromConfig(
+  themeConfig: ThemeConfigInput,
+): ThemeSnapshot {
+  return {
+    tint: themeConfig.tint,
+    darkMode: themeConfig.darkMode,
+    neutral: themeConfig.neutral,
+    radiusScale: themeConfig.radiusScale,
+  };
+}
+
+/**
+ * canonical document 에서 `themes` 필드를 `ThemeSnapshot` 으로 읽기.
+ *
+ * Phase 2 write-through 이전: read-only accessor.
+ * `themes` 필드가 없거나 ThemeSnapshot 구조가 아니면 `undefined` 반환.
+ *
+ * @param doc - canonical CompositionDocument
+ * @returns ThemeSnapshot 또는 undefined (themes 필드 없음)
+ */
+export function readCanonicalThemes(
+  doc: CompositionDocument,
+): ThemeSnapshot | undefined {
+  if (!doc.themes) return undefined;
+
+  // CompositionDocument.themes 현재 타입: Record<string, string[]> (stub)
+  // ThemeSnapshot 필드 존재 여부 확인 후 캐스팅
+  const raw = doc.themes as Record<string, unknown>;
+  if (
+    typeof raw["tint"] === "string" &&
+    typeof raw["darkMode"] === "string" &&
+    typeof raw["neutral"] === "string" &&
+    typeof raw["radiusScale"] === "string"
+  ) {
+    return {
+      tint: raw["tint"],
+      darkMode: raw["darkMode"],
+      neutral: raw["neutral"],
+      radiusScale: raw["radiusScale"],
+      ...(raw["customTokens"] &&
+      typeof raw["customTokens"] === "object" &&
+      raw["customTokens"] !== null
+        ? {
+            customTokens: raw["customTokens"] as Record<string, string>,
+          }
+        : {}),
+    };
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
ADR-910 (canonical themes/variables land plan) Phase 1 — themes 의 ADR-021 themeConfigStore 통합. Alternative B (read-only snapshot adapter) 적용.

신규
- adapters/canonical/themesAdapter.ts:
  - ThemeSnapshot 인터페이스 (tint/darkMode/neutral/radiusScale + customTokens 슬롯 예약 — ADR-910 R2)
  - ThemeConfigInput 최소 계약 인터페이스
  - snapshotThemesFromConfig(themeConfig) — call-time 직렬화 pure function (ADR-910 R4 stale 방지)
  - readCanonicalThemes(doc) — canonical document 에서 ThemeSnapshot read

수정
- adapters/canonical/index.ts:
  - LegacyAdapterDeps 에 getThemeConfig?: () => ThemeConfigInput 옵션
  - legacyToCanonical() 내부에서 themes snapshot 주입
  - 미전달 시 doc.themes = undefined (BC)

검증
- type-check 3/3 PASS
- vitest 49/49 PASS (기존 37 회귀 0 + 신규 12 추가)

Phase 2 후속
- variables 통합 (ADR-022 TokenRef resolver)
- CompositionDocument.themes 타입 공식화 (현재 stub 캐스팅)
- baseTypography 확장 (ADR-056 영역, 별도 ADR)