### PR TITLE
chore(adr-903): preview/App.tsx P2 dev 로그 정리 — root cause 확정 후 revert

### DIFF
--- a/apps/builder/src/preview/App.tsx
+++ b/apps/builder/src/preview/App.tsx
@@ -154,25 +154,7 @@ function CanvasContent() {
       const refCount = doc.children.filter((c) => c.type === "ref").length;
       const reusableCount = doc.children.filter((c) => c.reusable).length;
 
-      // [DEBUG] resolver 가 빈 배열 반환하는 root cause 진단용 추가 출력.
-      // ADR-903 옵션 C 검증 후 제거.
-      const childrenSummary = doc.children.slice(0, 5).map((c) => ({
-        id: c.id,
-        type: c.type,
-        reusable: c.reusable ?? false,
-        metaType: (c.metadata as Record<string, unknown> | undefined)?.type,
-        metaPageId: (c.metadata as Record<string, unknown> | undefined)?.pageId,
-      }));
-      const resolvedSummary = resolved.slice(0, 5).map((n) => ({
-        id: n.id,
-        type: n.type,
-        metaType: (n.metadata as Record<string, unknown> | undefined)?.type,
-        metaPageId: (n.metadata as Record<string, unknown> | undefined)?.pageId,
-      }));
-
-      // [DEBUG v2] Chrome MCP console reader 가 Object detail 미캡처 →
-      // JSON.stringify 으로 string serialize 출력
-      const debugPayload = {
+      console.log("[ADR-903 P2] canonical resolve", {
         input: {
           elements: elements.length,
           pages: pages.length,
@@ -185,22 +167,13 @@ function CanvasContent() {
           children: doc.children.length,
           reusables: reusableCount,
           refs: refCount,
-          childrenSummary,
         },
         resolved: {
           rootCount: resolved.length,
-          summary: resolvedSummary,
         },
-      };
-      console.log("[ADR-903 P2] canonical resolve", debugPayload);
-      console.log("[ADR-903 P2 STRING]", JSON.stringify(debugPayload, null, 2));
+      });
     } catch (err) {
       console.warn("[ADR-903 P2] canonical resolve failed", err);
-      console.warn(
-        "[ADR-903 P2 STRING] error:",
-        String(err),
-        err instanceof Error ? err.stack : "",
-      );
     }
   }, [elements, pages, layouts, currentPageId, currentLayoutId]);
 


### PR DESCRIPTION
ADR-903 옵션 C resolve 0 root cause (UPDATE_PAGES sender 누락) 확정 + fix/adr-903-canonical-pages-hydration 으로 해결. 본 commit 은 진단 목적의 임시 디버깅 코드 정리.

Revert 대상
- apps/builder/src/preview/App.tsx:157-171 의 childrenSummary / resolvedSummary 추가 출력 제거
- 기본 P2 dev 로그 (input / document / resolved 단순 count) 만 유지

Why now
- 진짜 root cause 가 builder side sender 누락임이 확정됨 (resolver 로직 정상)
- 추가 진단 출력은 상시 유지 가치 없음 (필요 시 git history 에서 복원 가능)
- Chrome MCP 검증으로 옵션 C 첫 정상 작동 확인 (data-canonical-id DOM 마커 부착)

후속
- debug branch v2 (debug/adr-903-canonical-resolve-zero-v2) 의 JSON.stringify 출력은 본 revert 와 별개 — 미머지 상태이므로 close 권장 (사용자)

검증
- type-check 3/3 PASS