### PR TITLE
feat(adr-903): 옵션 C canonical render path default 활성화

### DIFF
--- a/apps/builder/src/preview/App.tsx
+++ b/apps/builder/src/preview/App.tsx
@@ -43,16 +43,25 @@ import type { Layout } from "../types/builder/layout.types";
 import { CanonicalNodeRenderer } from "./components/CanonicalNodeRenderer";
 
 /**
- * URL param `?canonical=1` 시 canonical renderer 경로를 활성화한다.
+ * Canonical renderer 경로 활성화 결정.
  *
- * 모듈-레벨 상수로 평가 — 컴포넌트 재렌더링마다 재계산되지 않음.
- * production 에서도 동일하게 동작 (legacy-path 기본).
+ * - 기본 동작: 활성화 (canonical render path)
+ * - URL param `?canonical=0` 으로 명시적 opt-out 가능 (legacy fallback)
+ * - 모듈-레벨 상수로 평가 — 컴포넌트 재렌더링마다 재계산되지 않음
+ * - production 에서도 동일하게 동작
+ *
+ * Why default true:
+ * - ADR-903 P2 옵션 C 검증 PASS (Chrome MCP, 2026-04-25 세션 28)
+ * - canonical resolve 정상 작동 + DOM dual marker (data-canonical-id +
+ *   data-legacy-uuid) 부착 확인
+ * - canonical render 실패 시 안전망 (legacy fallback) 정상 작동
+ * - pages hydration sender (UPDATE_PAGES) land 후 production 데이터 검증 완료
  */
 const USE_CANONICAL_RENDER: boolean = (() => {
   try {
-    return new URLSearchParams(window.location.search).get("canonical") === "1";
+    return new URLSearchParams(window.location.search).get("canonical") !== "0";
   } catch {
-    return false;
+    return true;
   }
 })();
 


### PR DESCRIPTION
P2 옵션 C 검증 PASS (Chrome MCP, 2026-04-25 세션 28) 후 USE_CANONICAL_RENDER default true 로 전환. 기존 ?canonical=1 opt-in 패턴을 ?canonical=0 opt-out 으로 반전.

검증 근거
- pages hydration sender (UPDATE_PAGES) land 후 production 데이터에서 canonical resolve 정상 작동
- DOM dual marker (data-canonical-id + data-legacy-uuid) 부착 확인
- legacy fallback 안전망 정상 작동 (canonical 실패 시 graceful degradation)

변경
- preview/App.tsx:51-57 USE_CANONICAL_RENDER 평가 로직 반전
  - Before: param === "1" → true (opt-in)
  - After:  param !== "0" → true (opt-out)
- catch 분기 default 도 false → true 로 변경 (URLSearchParams 실패 시 default 활성화)

Base
- 본 branch 는 fix/adr-903-canonical-pages-hydration base — fix 머지 후 머지

검증 (사용자 권장)
1. 본 PR + fix PR 머지 후 builder 접속 (URL param 없이)
2. Console "[ADR-903 P2]" 로그에서 resolved.rootCount > 0 확인
3. DOM data-canonical-id count > 0 확인
4. ?canonical=0 으로 legacy fallback 동작 확인

후속
- ADR-903 본문 §3 옵션 C status 갱신 (default true 반영)
- preview 의 P2 dev 로그 정리 (debug revert PR 별도)

검증
- type-check 3/3 PASS