### PR TITLE
feat(adr-903): getCanonicalParentId + buildParentIndex helper — P3-B …

### DIFF
--- a/apps/builder/src/resolvers/canonical/__tests__/storeBridge.test.ts
+++ b/apps/builder/src/resolvers/canonical/__tests__/storeBridge.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview storeBridge helper 단위 테스트 — ADR-903 P2 D-B
+ * @fileoverview storeBridge helper 단위 테스트 — ADR-903 P2 D-B + P3-B
  *
  * 검증 대상:
  * - `selectResolvedTree(state, pages, layouts, cache?)` — store snapshot 진입점
@@ -7,6 +7,8 @@
  * - `extractLegacyPropsFromResolved(resolved)` — 두 metadata 패턴 대응
  * - `resolveInstanceWithSharedCache(instance, master, cache?)` — mini-doc + cache 통과한
  *   Element 재구성 — legacy `resolveInstanceElement` 와 시각 등가성 보장
+ * - `buildParentIndex(tree)` — DFS child → parent id Map (P3-B)
+ * - `getCanonicalParentId(index, elementId)` — canonical parent id 조회 (P3-B)
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import type { Element, Page } from "@/types/builder/unified.types";
@@ -17,7 +19,9 @@ import type { CanonicalNode, RefNode, ResolvedNode } from "@composition/shared";
 import { resolveInstanceElement } from "@/utils/component/instanceResolver";
 import {
   buildResolvedNodeIndex,
+  buildParentIndex,
   extractLegacyPropsFromResolved,
+  getCanonicalParentId,
   resolveInstanceWithSharedCache,
   selectResolvedTree,
 } from "../storeBridge";
@@ -559,6 +563,8 @@ describe("resolveInstanceWithSharedCache — D-C 안전망 회귀", () => {
     expect(canonical?.masterId).toBe("m7");
   });
 
+  // P3-B tests are appended after TC21
+
   it("TC21: deeply-nested style 객체 — color + 추가 필드 (border) 머지", () => {
     const master: Element = el({
       id: "m8",
@@ -593,5 +599,162 @@ describe("resolveInstanceWithSharedCache — D-C 안전망 회귀", () => {
     expect(style.backgroundColor).toBe("white"); // master 보존
     expect(style.padding).toBe(8); // master 보존
     expect(style.border).toBe("1px solid blue"); // override 신규
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// P3-B: buildParentIndex + getCanonicalParentId
+//
+// ADR-903 P3-D-5 사용 패턴: `getCanonicalParentId(index, el.id) === id`
+// 설계 문서: docs/adr/design/903-phase3d-runtime-breakdown.md §4.5
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("buildParentIndex", () => {
+  it("TC-P1: root 노드의 parentId → 없음 (Map에 등록 안 됨)", () => {
+    const tree: ResolvedNode[] = [{ id: "root", type: "frame" }];
+    const index = buildParentIndex(tree);
+    // root 는 부모가 없으므로 등록 안 됨
+    expect(index.has("root")).toBe(false);
+  });
+
+  it("TC-P2: 1단 child → 부모 id 가 Map에 등록됨", () => {
+    const tree: ResolvedNode[] = [
+      {
+        id: "root",
+        type: "frame",
+        children: [
+          { id: "child-A", type: "Button" },
+          { id: "child-B", type: "Text" },
+        ],
+      },
+    ];
+    const index = buildParentIndex(tree);
+    expect(index.get("child-A")).toBe("root");
+    expect(index.get("child-B")).toBe("root");
+  });
+
+  it("TC-P3: 3단 중첩 — 각 노드가 직속 부모 id 를 가짐", () => {
+    const tree: ResolvedNode[] = [
+      {
+        id: "page",
+        type: "frame",
+        children: [
+          {
+            id: "section",
+            type: "Section",
+            children: [
+              {
+                id: "card",
+                type: "Card",
+                children: [{ id: "label", type: "Label" }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const index = buildParentIndex(tree);
+    expect(index.get("section")).toBe("page");
+    expect(index.get("card")).toBe("section");
+    expect(index.get("label")).toBe("card");
+    // root 는 부모 없음
+    expect(index.has("page")).toBe(false);
+  });
+
+  it("TC-P4: 복수 root 노드 — 각 root 의 자식 모두 등록", () => {
+    const tree: ResolvedNode[] = [
+      {
+        id: "frame-1",
+        type: "frame",
+        children: [{ id: "btn-1", type: "Button" }],
+      },
+      {
+        id: "frame-2",
+        type: "frame",
+        children: [{ id: "btn-2", type: "Button" }],
+      },
+    ];
+    const index = buildParentIndex(tree);
+    expect(index.get("btn-1")).toBe("frame-1");
+    expect(index.get("btn-2")).toBe("frame-2");
+    expect(index.has("frame-1")).toBe(false);
+    expect(index.has("frame-2")).toBe(false);
+  });
+});
+
+describe("getCanonicalParentId", () => {
+  it("TC-P5: root element → null (부모 없음)", () => {
+    const tree: ResolvedNode[] = [
+      {
+        id: "root",
+        type: "frame",
+        children: [{ id: "child", type: "Button" }],
+      },
+    ];
+    const index = buildParentIndex(tree);
+    expect(getCanonicalParentId(index, "root")).toBeNull();
+  });
+
+  it("TC-P6: 1단 child → root id 반환", () => {
+    const tree: ResolvedNode[] = [
+      {
+        id: "root",
+        type: "frame",
+        children: [{ id: "child", type: "Button" }],
+      },
+    ];
+    const index = buildParentIndex(tree);
+    expect(getCanonicalParentId(index, "child")).toBe("root");
+  });
+
+  it("TC-P7: 3단 중첩 child → 직속 부모 id 반환 (조상 아님)", () => {
+    const tree: ResolvedNode[] = [
+      {
+        id: "page",
+        type: "frame",
+        children: [
+          {
+            id: "section",
+            type: "Section",
+            children: [{ id: "deep", type: "Button" }],
+          },
+        ],
+      },
+    ];
+    const index = buildParentIndex(tree);
+    // deep 의 직속 부모는 section (page 아님)
+    expect(getCanonicalParentId(index, "deep")).toBe("section");
+    expect(getCanonicalParentId(index, "deep")).not.toBe("page");
+  });
+
+  it("TC-P8: 존재하지 않는 elementId → null", () => {
+    const tree: ResolvedNode[] = [{ id: "root", type: "frame" }];
+    const index = buildParentIndex(tree);
+    expect(getCanonicalParentId(index, "nonexistent-id")).toBeNull();
+  });
+
+  it("TC-P9: ref instance (reusable master child) → instance root id 반환", () => {
+    // ResolvedNode 트리에서 ref instance 는 _resolvedFrom 을 가짐.
+    // buildParentIndex 는 resolved tree 의 실제 구조 기준으로 parent 를 기록하므로
+    // instance 의 부모 = instance 를 children 으로 포함한 노드의 id.
+    const tree: ResolvedNode[] = [
+      {
+        id: "page-node",
+        type: "frame",
+        children: [
+          {
+            id: "instance-btn",
+            type: "Button",
+            _resolvedFrom: "master-btn",
+            children: [{ id: "instance-label", type: "Label" }],
+          },
+        ],
+      },
+    ];
+    const index = buildParentIndex(tree);
+    // instance 자체의 부모 = page-node
+    expect(getCanonicalParentId(index, "instance-btn")).toBe("page-node");
+    // instance 의 resolved 자식 부모 = instance-btn
+    expect(getCanonicalParentId(index, "instance-label")).toBe("instance-btn");
   });
 });

--- a/apps/builder/src/resolvers/canonical/storeBridge.ts
+++ b/apps/builder/src/resolvers/canonical/storeBridge.ts
@@ -101,6 +101,64 @@ function visit(node: ResolvedNode, index: Map<string, ResolvedNode>): void {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// 2.5) ResolvedNode 트리 → child id → parent id Map 빌드 (P3-B)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * resolved tree 를 DFS 순회하여 child id → parent id Map 을 빌드한다.
+ *
+ * ADR-903 P3-D-2 (`elementCreation.ts` 히스토리 조건) / P3-D-5 (`BuilderCore`
+ * 필터링 경로) 가 `el.layout_id === id` 패턴을 canonical parent context 기반으로
+ * 교체할 때 사용한다.
+ *
+ * - root 노드는 부모가 없으므로 Map 에 등록되지 않는다 (`index.has(rootId) === false`)
+ * - DFS pre-order 로 traverse — 동일 id 가 트리 내 여러 곳에 등장하면 마지막
+ *   occurrence 의 부모가 우선
+ * - 단방향 (child → parent). parent → children 은 ResolvedNode.children 으로 직접 접근
+ *
+ * 설계 문서: `docs/adr/design/903-phase3d-runtime-breakdown.md` §4.5
+ */
+export function buildParentIndex(tree: ResolvedNode[]): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const node of tree) {
+    visitParent(node, undefined, index);
+  }
+  return index;
+}
+
+function visitParent(
+  node: ResolvedNode,
+  parentId: string | undefined,
+  index: Map<string, string>,
+): void {
+  if (parentId !== undefined) {
+    index.set(node.id, parentId);
+  }
+  if (node.children) {
+    for (const child of node.children) {
+      visitParent(child, node.id, index);
+    }
+  }
+}
+
+/**
+ * `buildParentIndex` 결과에서 element id 의 canonical parent id 를 조회한다.
+ *
+ * - root 노드 → `null` (Map 에 등록 안 됨)
+ * - 존재하지 않는 id → `null`
+ * - 그 외 → 직속 부모 id (조상 아님)
+ *
+ * 사용 사이트는 정렬된 `Map` 을 받아 O(1) 조회를 보장. 매 호출마다 tree 를
+ * 재순회하지 않도록 caller 에서 index 를 한 번만 빌드해 재사용해야 한다.
+ */
+export function getCanonicalParentId(
+  index: Map<string, string>,
+  elementId: string,
+): string | null {
+  return index.get(elementId) ?? null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // 3) ResolvedNode → legacy props 추출 (두 metadata 패턴 대응)
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
…잔여 보강

- canonical resolved tree 의 child id → parent id Map 빌드 + 조회 helper 신규
- API: buildParentIndex(tree): Map<string,string> + getCanonicalParentId(index, id): string|null
- 기존 buildResolvedNodeIndex 의 visit DFS 패턴과 일관 (pre-order, 동일 id 마지막 occurrence 우선)
- root 노드는 Map 미등록 — getCanonicalParentId 가 null 반환
- 30 vitest tests (RED→GREEN), edge: root/1단/3단 nested/missing/multi-root/ref instance
- ADR-903 P3-D-2 (elementCreation 히스토리 조건) + P3-D-5 (BuilderCore 필터링) 진입 hard precondition 충족
- 설계: docs/adr/design/903-phase3d-runtime-breakdown.md §4.5
- 브랜치: feat/adr-903-p3b-canonical-parent-helper (main 아님)