### PR TITLE
test(adr-903): P3-D-4 Phase A RED — usePageManager + useIframeMesseng…

### DIFF
--- a/apps/builder/src/builder/hooks/__tests__/useIframeMessenger.canonical.test.ts
+++ b/apps/builder/src/builder/hooks/__tests__/useIframeMessenger.canonical.test.ts
@@ -1,0 +1,54 @@
+/**
+ * ADR-903 P3-D-4 — useIframeMessenger UPDATE_ELEMENTS schema canonical 전환 검증
+ *
+ * 본 test 는 RED phase: GREEN 변환 (postMessage schema 의 layoutId →
+ * reusableFrameId + version: "composition-1.0" bump) 전까지 의도적으로 FAIL.
+ *
+ * 변환 목표:
+ * - message.version: "legacy-1.0" → "composition-1.0"
+ * - pageInfo.layoutId 필드 제거 또는 reusableFrameId 와 alias 병기
+ * - Preview 측 messageHandler.ts 가 신규 schema 수신 가능
+ *
+ * 참조:
+ * - docs/adr/design/903-phase3d-runtime-breakdown.md §4.4
+ * - 변환 위치: apps/builder/src/builder/hooks/useIframeMessenger.ts L196~235
+ */
+
+import { describe, it, expect } from "vitest";
+
+describe("P3-D-4: useIframeMessenger UPDATE_ELEMENTS schema 전환 (RED phase)", () => {
+  describe("postMessage version bump", () => {
+    // [RED] current: version: "legacy-1.0" 고정
+    // GREEN: version: "composition-1.0" 으로 bump
+    it("UPDATE_ELEMENTS message 의 version 이 'composition-1.0' 으로 bump 된다", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const filePath = path.resolve(__dirname, "../useIframeMessenger.ts");
+      const source = await fs.readFile(filePath, "utf-8");
+      // composition-1.0 등장이 확인되어야 함
+      expect(source).toMatch(/version:\s*"composition-1\.0"/);
+      // legacy-1.0 의 leftover 가 없어야 함 (UPDATE_ELEMENTS 메시지 한정)
+      const updateElementsBlock = source.match(
+        /const message = \{[\s\S]{0,300}type: "UPDATE_ELEMENTS"[\s\S]{0,300}\};/,
+      );
+      expect(
+        updateElementsBlock,
+        "UPDATE_ELEMENTS message 객체 추출 실패 — 시그니처 변경 시 regex 동기화",
+      ).not.toBeNull();
+      expect(updateElementsBlock![0]).not.toMatch(/version:\s*"legacy-1\.0"/);
+    });
+  });
+
+  describe("pageInfo schema canonical 전환", () => {
+    // [RED] current: pageInfo.layoutId 만 사용
+    // GREEN: pageInfo.reusableFrameId 추가 (또는 layoutId → reusableFrameId rename)
+    it("pageInfo 에 reusableFrameId 필드가 등장한다", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const filePath = path.resolve(__dirname, "../useIframeMessenger.ts");
+      const source = await fs.readFile(filePath, "utf-8");
+      // reusableFrameId 식별자 등장
+      expect(source).toMatch(/reusableFrameId/);
+    });
+  });
+});

--- a/apps/builder/src/builder/hooks/__tests__/usePageManager.canonical.test.ts
+++ b/apps/builder/src/builder/hooks/__tests__/usePageManager.canonical.test.ts
@@ -1,0 +1,88 @@
+/**
+ * ADR-903 P3-D-4 — usePageManager.initializeProject canonical document 전환 검증
+ *
+ * 본 test 는 RED phase: GREEN 변환 (initializeProject 의 layout loading 을
+ * canonical reusable FrameNode 순회로 교체) 전까지 의도적으로 FAIL.
+ *
+ * 변환 목표:
+ * - `db.elements.getByLayout(layoutId)` 호출 제거
+ * - `pages.layout_id` 기반 layoutIds 수집 제거
+ * - canonical document 의 reusable FrameNode 들에서 element 로드
+ *
+ * 참조:
+ * - docs/adr/design/903-phase3d-runtime-breakdown.md §4.4
+ * - 변환 위치: apps/builder/src/builder/hooks/usePageManager.ts:473~535
+ *
+ * RED → GREEN 전략 (Phase B/C):
+ * - Phase B: useIframeMessenger postMessage schema 변환
+ * - Phase C: usePageManager initializeProject canonical lookup
+ */
+
+import { describe, it, expect } from "vitest";
+
+describe("P3-D-4: usePageManager.initializeProject canonical 전환 (RED phase)", () => {
+  describe("initializeProject — canonical document load", () => {
+    // [RED] current: db.elements.getByLayout(layoutId) 사용 → ownership marker 의존
+    // GREEN: canonical reusable FrameNode 순회로 element 로드
+    it("getByLayout(layoutId) 호출이 제거된다 — canonical reusable FrameNode 순회로 대체", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const filePath = path.resolve(__dirname, "../usePageManager.ts");
+      const rawSource = await fs.readFile(filePath, "utf-8");
+      // 라인 코멘트 제거 — TODO 코멘트 false-positive 차단
+      const source = rawSource.replace(/\/\/.*$/gm, "");
+      // initializeProject 함수 안에서 db.elements.getByLayout 호출이 0건이어야 함
+      // (다른 함수의 getByLayout 호출은 제거 대상 아님)
+      const initFnMatch = source.match(
+        /const initializeProject[\s\S]+?(?=\n\n  const |\n\n  return |\n  \};\n)/,
+      );
+      expect(
+        initFnMatch,
+        "initializeProject 함수 추출 실패 — 시그니처 변경 시 본 test 의 regex 도 동기화 필요",
+      ).not.toBeNull();
+      const initFnSource = initFnMatch![0];
+      expect(initFnSource).not.toMatch(/db\.elements\.getByLayout/);
+    });
+
+    // [RED] current: pages.layout_id 기반 layoutIds 수집 → ownership marker
+    // GREEN: canonical doc 에서 reusable FrameNode id 직접 추출
+    it("pages.layout_id 기반 layoutIds 수집 패턴이 제거된다", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const filePath = path.resolve(__dirname, "../usePageManager.ts");
+      const rawSource = await fs.readFile(filePath, "utf-8");
+      const source = rawSource.replace(/\/\/.*$/gm, "");
+      const initFnMatch = source.match(
+        /const initializeProject[\s\S]+?(?=\n\n  const |\n\n  return |\n  \};\n)/,
+      );
+      expect(initFnMatch).not.toBeNull();
+      const initFnSource = initFnMatch![0];
+      // projectPages.map((p) => (p as { layout_id?: ... }).layout_id) 패턴
+      expect(initFnSource).not.toMatch(
+        /projectPages[\s\S]{0,80}layout_id\?:\s*string \| null/,
+      );
+    });
+
+    // [RED] current: canonical resolver 미사용 (코멘트 TODO 만 존재)
+    // GREEN: selectCanonicalDocument(...) 또는 selectCanonicalReusableFrames(...)
+    // 실제 호출 (괄호 포함) 등장 — 코멘트 제거 후 검사
+    it("canonical resolver (selectCanonicalDocument 또는 selectCanonicalReusableFrames) 가 호출된다", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const filePath = path.resolve(__dirname, "../usePageManager.ts");
+      const rawSource = await fs.readFile(filePath, "utf-8");
+      // 라인 코멘트 제거 — TODO 코멘트의 "selectCanonicalReusableFrames()"
+      // false-positive 매칭 차단
+      const source = rawSource.replace(/\/\/.*$/gm, "");
+      const initFnMatch = source.match(
+        /const initializeProject[\s\S]+?(?=\n\n  const |\n\n  return |\n  \};\n)/,
+      );
+      expect(initFnMatch).not.toBeNull();
+      const initFnSource = initFnMatch![0];
+      // 호출 형태 (괄호) 만 매칭
+      expect(initFnSource).toMatch(
+        /selectCanonicalDocument\(|selectCanonicalReusableFrames\(/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
…er canonical 전환 검증

ADR-903 P3-D-4 (CRITICAL, 5h 작업) 의 Phase A — RED test 5건 작성. GREEN 변환 (Phase B/C) 전까지 의도적 FAIL.

테스트 분류 (5 actual):
- usePageManager.initializeProject canonical 전환 (3 cases):
  - getByLayout(layoutId) 호출이 제거된다
  - pages.layout_id 기반 layoutIds 수집 패턴이 제거된다
  - canonical resolver (selectCanonicalDocument 또는 selectCanonicalReusableFrames) 가 호출된다
- useIframeMessenger UPDATE_ELEMENTS schema 전환 (2 cases):
  - message.version 이 'composition-1.0' 으로 bump 된다 (현재 'legacy-1.0')
  - pageInfo 에 reusableFrameId 필드가 등장한다 (현재 layoutId 만)

검증 결과 (RED phase):
- Tests 5 failed | 0 passed (5 total) — 모두 expected RED
- pnpm type-check: PASS

전략:
- grep-based static test (P3-D-2 의 dead-code grep test 와 동일 패턴)
- 코멘트 제거 (`/\/\/.*$/gm`) 후 검사 — TODO 코멘트 false-positive 차단
- initializeProject 함수 단위 추출 — 다른 함수의 ownership marker 사용은 P3-D-4 scope 외

Phase 분리 plan:
- Phase A (본 commit): RED test ~1h ✓
- Phase B (다음 PR): useIframeMessenger postMessage schema ~1.5h
- Phase C (다음 PR): usePageManager initializeProject canonical lookup ~1.5h
- Phase D (다음 PR): Chrome MCP 통합 검증 ~1h

의존성 (모두 충족):
- ✅ P2 옵션 C default 활성화 (PR #227, db462688)
- ✅ P3-D-3 layoutActions canonical 머지
- ✅ P3-D-2 push 완료 (PR 머지 대기 — Phase B/C 진입 시점에 머지 권장)

참조:
- docs/adr/903-ref-descendants-slot-composition-format-migration-plan.md
- docs/adr/design/903-phase3d-runtime-breakdown.md §4.4