### PR TITLE
feat(adr-903): P3-D-4 Phase B GREEN — UPDATE_ELEMENTS schema canonica…

### DIFF
--- a/apps/builder/src/builder/hooks/useIframeMessenger.ts
+++ b/apps/builder/src/builder/hooks/useIframeMessenger.ts
@@ -202,10 +202,18 @@ export const useIframeMessenger = (): UseIframeMessengerReturn => {
 
     // Layout 편집 모드: pageId=null, layoutId=currentLayoutId
     // Page 모드: pageId=currentPageId, layoutId=page.layout_id (Page에 적용된 Layout)
-    const pageInfo =
+    // ADR-903 P3-D-4 Phase B: reusableFrameId 신규 field — canonical model 의
+    // reusable frame 식별자. 현 시점 layoutId 와 동일 의미 (alias). Preview 가
+    // version 으로 분기해 신규 field 우선 사용 가능. legacy layoutId 는 BC 위해 유지.
+    const layoutId =
       currentEditMode === "layout"
-        ? { pageId: null, layoutId: layoutStoreLayoutId }
-        : { pageId: currentPageId, layoutId: currentPage?.layout_id || null };
+        ? layoutStoreLayoutId
+        : currentPage?.layout_id || null;
+    const pageInfo = {
+      pageId: currentEditMode === "layout" ? null : currentPageId,
+      layoutId,
+      reusableFrameId: layoutId,
+    };
 
     // iframe이 준비되지 않았으면 큐에 넣기
     if (currentReadyState !== "ready" || !iframe?.contentWindow) {
@@ -216,12 +224,12 @@ export const useIframeMessenger = (): UseIframeMessengerReturn => {
       return;
     }
 
-    // ADR-903 P3-B 안전망 #3: version 스텁 추가
-    // P3-D에서 canonical resolver 전환 시 "composition-1.0" 으로 bump.
-    // Preview가 version 필드로 payload 형식 분기 가능.
+    // ADR-903 P3-D-4 Phase B: version bump
+    // - legacy-1.0 → composition-1.0 (canonical resolver 전환 완료 신호)
+    // - Preview 가 version 으로 reusableFrameId vs layoutId 우선순위 분기
     const message = {
       type: "UPDATE_ELEMENTS",
-      version: "legacy-1.0" as const,
+      version: "composition-1.0" as const,
       elements: scopedElements,
       pageInfo,
     };
@@ -495,15 +503,20 @@ export const useIframeMessenger = (): UseIframeMessengerReturn => {
     queue.forEach((item) => {
       if (item.type === "UPDATE_ELEMENTS") {
         // ⭐ Layout/Slot System: 새 payload 형식 (elements + pageInfo)
+        // ADR-903 P3-D-4 Phase B: reusableFrameId 추가 (layoutId alias)
         const payload = item.payload as {
           elements: Element[];
-          pageInfo: { pageId: string | null; layoutId: string | null };
+          pageInfo: {
+            pageId: string | null;
+            layoutId: string | null;
+            reusableFrameId?: string | null;
+          };
         };
-        // ADR-903 P3-B 안전망 #3: version 스텁 (큐 경로)
+        // ADR-903 P3-D-4 Phase B: version composition-1.0 (큐 경로 동기화)
         iframe.contentWindow!.postMessage(
           {
             type: "UPDATE_ELEMENTS",
-            version: "legacy-1.0" as const,
+            version: "composition-1.0" as const,
             elements: payload.elements,
             pageInfo: payload.pageInfo,
           },

--- a/apps/builder/src/preview/messaging/messageHandler.ts
+++ b/apps/builder/src/preview/messaging/messageHandler.ts
@@ -44,9 +44,13 @@ export interface UpdateElementsMessage {
   type: "UPDATE_ELEMENTS";
   elements: PreviewElement[];
   // ⭐ Layout/Slot System: pageInfo도 함께 전송 (초기 로드 시 Layout 렌더링용)
+  // ADR-903 P3-D-4 Phase B: reusableFrameId 신규 field — canonical model 의
+  // reusable frame 식별자 (현 시점 layoutId 와 동일 의미). legacy layoutId 는
+  // BC 유지, Phase C/D 에서 reusableFrameId 우선 처리 추가 예정.
   pageInfo?: {
     pageId: string | null;
     layoutId: string | null;
+    reusableFrameId?: string | null;
   };
 }
 

--- a/apps/builder/src/preview/types/index.ts
+++ b/apps/builder/src/preview/types/index.ts
@@ -75,9 +75,11 @@ export interface UpdateElementsMessage extends PreviewMessage {
   type: "UPDATE_ELEMENTS";
   elements: PreviewElement[];
   // ⭐ Layout/Slot System: Page 정보 포함 (초기 로드 시 Layout 렌더링용)
+  // ADR-903 P3-D-4 Phase B: reusableFrameId alias 추가 (BC 유지)
   pageInfo?: {
     pageId: string | null;
     layoutId: string | null;
+    reusableFrameId?: string | null;
   };
 }
 


### PR DESCRIPTION
…l bump

ADR-903 P3-D-4 Phase B (useIframeMessenger postMessage schema 변환).

변경 내역:
1. apps/builder/src/builder/hooks/useIframeMessenger.ts:
   - UPDATE_ELEMENTS message version: "legacy-1.0" → "composition-1.0"
   - pageInfo schema 확장: { pageId, layoutId, reusableFrameId }
   - reusableFrameId = layoutId alias (현 시점 동일 의미, BC 보존)
   - sendElementsToIframe 본 경로 + processMessageQueue 큐 경로 양쪽 동기화
2. apps/builder/src/preview/messaging/messageHandler.ts:
   - UpdateElementsMessage interface 의 pageInfo 에 reusableFrameId?: string | null 추가
3. apps/builder/src/preview/types/index.ts:
   - 동일 schema 확장

전략 — BC 보존:
- legacy field (layoutId) 유지 → Preview 의 기존 layoutId 처리 로직 변경 없음
- 신규 field (reusableFrameId) 추가 + version bump → Phase C/D 에서 reusableFrameId 우선 처리 추가 시 분기 가능
- 즉시 preview render 회귀 0 (BC field 그대로 사용)

검증:
- useIframeMessenger.canonical.test.ts: 2/2 PASS (version composition-1.0 + reusableFrameId 등장)
- usePageManager.canonical.test.ts: 3/3 still RED (Phase C 의 작업, expected)
- pnpm type-check: PASS (3/3 successful)

다음 단계:
- Phase C: usePageManager.initializeProject canonical resolver lookup
- Phase D: Chrome MCP 통합 검증 (preview render 회귀 없음 확증)

참조:
- docs/adr/design/903-phase3d-runtime-breakdown.md §4.4
- 변환 위치: useIframeMessenger.ts L196~228, L500~520