### PR TITLE
feat(adr-903): P3-E E-3 RED + GREEN — runLegacyToCanonicalMigration d…

### DIFF
--- a/apps/builder/src/lib/db/__tests__/migration.test.ts
+++ b/apps/builder/src/lib/db/__tests__/migration.test.ts
@@ -1,0 +1,416 @@
+// @vitest-environment jsdom
+
+/**
+ * ADR-903 P3-E E-3 — runLegacyToCanonicalMigration (read-through dry-run)
+ *
+ * legacy ownership marker (page_id / layout_id) 를 canonical parent ID 로 변환
+ * 계산하는 dry-run 함수. DB 무변경 — 실제 write 는 E-6 에서.
+ *
+ * 검증 시나리오:
+ * - core contract: skip / dry-run / backup / transformations
+ * - 50+ legacy fixture round-trip — layout / page / orphan / mixed
+ *
+ * RED → GREEN 전략:
+ * - RED: production 파일 (`migration.ts`) 부재 시 import 실패로 모든 it FAIL
+ * - GREEN: runLegacyToCanonicalMigration 구현 후 ALL PASS
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { CompositionDocument } from "@composition/shared";
+import type { Element } from "../../../types/core/store.types";
+import type { Layout } from "../../../types/builder/layout.types";
+import type { MetaRecord } from "../types";
+
+// ─────────────────────────────────────────────
+// Mock — createMigrationBackup
+// ─────────────────────────────────────────────
+
+vi.mock("../migrationBackup", () => ({
+  createMigrationBackup: vi.fn(
+    async (_adapter: unknown, projectId: string) =>
+      `composition-migration-backup:${projectId}:1700000000000`,
+  ),
+}));
+
+// ─────────────────────────────────────────────
+// Mock adapter helper
+// ─────────────────────────────────────────────
+
+type MockMetaRecord = MetaRecord | null;
+
+interface MockAdapter {
+  elements: {
+    getAll: ReturnType<typeof vi.fn>;
+    insert: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    updateMany: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
+  };
+  layouts: {
+    getAll: ReturnType<typeof vi.fn>;
+    insert: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+  meta: {
+    get: ReturnType<typeof vi.fn>;
+    set: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+}
+
+function buildMockAdapter(
+  elements: Element[],
+  layouts: Layout[],
+  metaRecord: MockMetaRecord = null,
+): MockAdapter {
+  return {
+    elements: {
+      getAll: vi.fn(async () => elements),
+      insert: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    layouts: {
+      getAll: vi.fn(async () => layouts),
+      insert: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    meta: {
+      get: vi.fn(async () => metaRecord),
+      set: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+}
+
+// ─────────────────────────────────────────────
+// canonical document fixture builders
+// ─────────────────────────────────────────────
+
+function buildPageNode(pageId: string) {
+  return {
+    id: pageId,
+    type: "ref" as const,
+    component: "page",
+    children: [],
+  };
+}
+
+function buildReusableFrameNode(frameId: string, name: string) {
+  return {
+    id: frameId,
+    type: "frame" as const,
+    reusable: true,
+    name,
+    children: [],
+  };
+}
+
+function buildDoc(opts: {
+  pageIds?: string[];
+  reusableFrameIds?: string[];
+}): CompositionDocument {
+  const children = [
+    ...(opts.pageIds ?? []).map(buildPageNode),
+    ...(opts.reusableFrameIds ?? []).map((id) =>
+      buildReusableFrameNode(id, id),
+    ),
+  ];
+  return {
+    version: "1.0",
+    children,
+    variables: {},
+    themes: { active: null, themes: {} },
+  } as unknown as CompositionDocument;
+}
+
+function buildElement(
+  id: string,
+  ownership: { page_id?: string | null; layout_id?: string | null },
+  extras: Partial<Element> = {},
+): Element {
+  return {
+    id,
+    page_id: ownership.page_id ?? null,
+    layout_id: ownership.layout_id ?? null,
+    parent_id: null,
+    tag: "Container",
+    props: {},
+    order_num: 0,
+    ...extras,
+  } as unknown as Element;
+}
+
+// ─────────────────────────────────────────────
+// Core contract tests
+// ─────────────────────────────────────────────
+
+describe("P3-E E-3: runLegacyToCanonicalMigration (read-through dry-run)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("core contract", () => {
+    it("runLegacyToCanonicalMigration 함수가 export 된다", async () => {
+      const mod = await import("../migration");
+      expect(typeof mod.runLegacyToCanonicalMigration).toBe("function");
+    });
+
+    it("이미 composition-1.0 schemaVersion 인 경우 status=skipped + transformations=[] + errors=[]", async () => {
+      const { runLegacyToCanonicalMigration } = await import("../migration");
+      const adapter = buildMockAdapter([], [], {
+        projectId: "proj-x",
+        schemaVersion: "composition-1.0",
+        migratedAt: "2026-04-26T00:00:00.000Z",
+      });
+      const doc = buildDoc({ pageIds: [], reusableFrameIds: [] });
+      const result = await runLegacyToCanonicalMigration(adapter, "proj-x", {
+        canonicalDoc: doc,
+      });
+      expect(result.status).toBe("skipped");
+      expect(result.transformations).toEqual([]);
+      expect(result.errors).toEqual([]);
+      expect(result.backupKey).toBeUndefined();
+    });
+
+    it("dry-run=true (default) — adapter write 메서드 호출 0건", async () => {
+      const { runLegacyToCanonicalMigration } = await import("../migration");
+      const elements: Element[] = [
+        buildElement("e1", { layout_id: "frame-A" }),
+        buildElement("e2", { page_id: "p1" }),
+      ];
+      const adapter = buildMockAdapter(elements, []);
+      const doc = buildDoc({
+        pageIds: ["p1"],
+        reusableFrameIds: ["layout-frame-A"],
+      });
+      await runLegacyToCanonicalMigration(adapter, "proj-y", {
+        canonicalDoc: doc,
+      });
+      expect(adapter.elements.insert).not.toHaveBeenCalled();
+      expect(adapter.elements.update).not.toHaveBeenCalled();
+      expect(adapter.elements.updateMany).not.toHaveBeenCalled();
+      expect(adapter.elements.delete).not.toHaveBeenCalled();
+      expect(adapter.elements.deleteMany).not.toHaveBeenCalled();
+      expect(adapter.layouts.insert).not.toHaveBeenCalled();
+      expect(adapter.layouts.update).not.toHaveBeenCalled();
+      expect(adapter.layouts.delete).not.toHaveBeenCalled();
+      expect(adapter.meta.set).not.toHaveBeenCalled();
+      expect(adapter.meta.update).not.toHaveBeenCalled();
+    });
+
+    it("createMigrationBackup 호출되고 backupKey 가 반환 결과에 포함된다", async () => {
+      const { runLegacyToCanonicalMigration } = await import("../migration");
+      const { createMigrationBackup } = await import("../migrationBackup");
+      const adapter = buildMockAdapter([], []);
+      const doc = buildDoc({ pageIds: [], reusableFrameIds: [] });
+      const result = await runLegacyToCanonicalMigration(adapter, "proj-z", {
+        canonicalDoc: doc,
+      });
+      expect(createMigrationBackup).toHaveBeenCalledWith(adapter, "proj-z");
+      expect(result.backupKey).toMatch(
+        /^composition-migration-backup:proj-z:\d+$/,
+      );
+    });
+
+    it("layout_id non-null element 는 transformations 에 canonical parent 와 함께 포함된다", async () => {
+      const { runLegacyToCanonicalMigration } = await import("../migration");
+      const elements = [buildElement("e1", { layout_id: "frame-A" })];
+      const adapter = buildMockAdapter(elements, []);
+      const doc = buildDoc({ reusableFrameIds: ["layout-frame-A"] });
+      const result = await runLegacyToCanonicalMigration(adapter, "proj-1", {
+        canonicalDoc: doc,
+      });
+      expect(result.transformations).toHaveLength(1);
+      expect(result.transformations[0]).toMatchObject({
+        elementId: "e1",
+        page_id_was: null,
+        layout_id_was: "frame-A",
+        canonicalParentId: "layout-frame-A",
+      });
+    });
+
+    it("page_id non-null element 는 transformations 에 page node ID 와 함께 포함된다", async () => {
+      const { runLegacyToCanonicalMigration } = await import("../migration");
+      const elements = [buildElement("e1", { page_id: "p1" })];
+      const adapter = buildMockAdapter(elements, []);
+      const doc = buildDoc({ pageIds: ["p1"] });
+      const result = await runLegacyToCanonicalMigration(adapter, "proj-2", {
+        canonicalDoc: doc,
+      });
+      expect(result.transformations).toHaveLength(1);
+      expect(result.transformations[0]).toMatchObject({
+        elementId: "e1",
+        page_id_was: "p1",
+        layout_id_was: null,
+        canonicalParentId: "p1",
+      });
+    });
+
+    it("orphan element (page_id=null, layout_id=null) 는 transformations 에 canonicalParentId=null 로 포함되고 errors 에 추가된다", async () => {
+      const { runLegacyToCanonicalMigration } = await import("../migration");
+      const elements = [buildElement("e1", {})];
+      const adapter = buildMockAdapter(elements, []);
+      const doc = buildDoc({});
+      const result = await runLegacyToCanonicalMigration(adapter, "proj-3", {
+        canonicalDoc: doc,
+      });
+      expect(result.transformations).toHaveLength(1);
+      expect(result.transformations[0]?.canonicalParentId).toBeNull();
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toMatch(/orphan/i);
+    });
+
+    it("canonical parent 미존재 element (layout_id=invalid) 는 errors 에 추가된다", async () => {
+      const { runLegacyToCanonicalMigration } = await import("../migration");
+      const elements = [buildElement("e1", { layout_id: "frame-MISSING" })];
+      const adapter = buildMockAdapter(elements, []);
+      const doc = buildDoc({ reusableFrameIds: ["layout-frame-A"] });
+      const result = await runLegacyToCanonicalMigration(adapter, "proj-4", {
+        canonicalDoc: doc,
+      });
+      expect(result.transformations[0]?.canonicalParentId).toBeNull();
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it("status 는 errors 가 비었을 때 success, errors 가 있을 때 failure", async () => {
+      const { runLegacyToCanonicalMigration } = await import("../migration");
+      // success case
+      const okAdapter = buildMockAdapter(
+        [buildElement("e1", { page_id: "p1" })],
+        [],
+      );
+      const okDoc = buildDoc({ pageIds: ["p1"] });
+      const okResult = await runLegacyToCanonicalMigration(
+        okAdapter,
+        "proj-ok",
+        {
+          canonicalDoc: okDoc,
+        },
+      );
+      expect(okResult.status).toBe("success");
+
+      // failure case (orphan)
+      const failAdapter = buildMockAdapter([buildElement("e2", {})], []);
+      const failResult = await runLegacyToCanonicalMigration(
+        failAdapter,
+        "proj-fail",
+        { canonicalDoc: buildDoc({}) },
+      );
+      expect(failResult.status).toBe("failure");
+    });
+  });
+
+  // ─────────────────────────────────────────────
+  // 50+ legacy fixture round-trip
+  // ─────────────────────────────────────────────
+
+  describe("50+ legacy fixture round-trip", () => {
+    type Fixture = {
+      name: string;
+      ownership: { page_id?: string | null; layout_id?: string | null };
+      docPages: string[];
+      docFrames: string[];
+      expectedCanonicalParentId: string | null;
+      expectError: boolean;
+    };
+
+    function makePageFixtures(): Fixture[] {
+      const out: Fixture[] = [];
+      for (let i = 1; i <= 15; i++) {
+        out.push({
+          name: `page element fixture #${i} — page_id=p${i}`,
+          ownership: { page_id: `p${i}` },
+          docPages: [`p${i}`],
+          docFrames: [],
+          expectedCanonicalParentId: `p${i}`,
+          expectError: false,
+        });
+      }
+      return out;
+    }
+
+    function makeLayoutFixtures(): Fixture[] {
+      const out: Fixture[] = [];
+      for (let i = 1; i <= 15; i++) {
+        out.push({
+          name: `layout element fixture #${i} — layout_id=frame-${i}`,
+          ownership: { layout_id: `frame-${i}` },
+          docPages: [],
+          docFrames: [`layout-frame-${i}`],
+          expectedCanonicalParentId: `layout-frame-${i}`,
+          expectError: false,
+        });
+      }
+      return out;
+    }
+
+    function makeOrphanFixtures(): Fixture[] {
+      const out: Fixture[] = [];
+      for (let i = 1; i <= 10; i++) {
+        out.push({
+          name: `orphan fixture #${i} — both null`,
+          ownership: { page_id: null, layout_id: null },
+          docPages: [`p${i}`],
+          docFrames: [`layout-frame-${i}`],
+          expectedCanonicalParentId: null,
+          expectError: true,
+        });
+      }
+      return out;
+    }
+
+    function makeMissingFrameFixtures(): Fixture[] {
+      const out: Fixture[] = [];
+      for (let i = 1; i <= 10; i++) {
+        out.push({
+          name: `missing frame fixture #${i} — layout_id=ghost-${i}`,
+          ownership: { layout_id: `ghost-${i}` },
+          docPages: [],
+          docFrames: ["layout-frame-A"],
+          expectedCanonicalParentId: null,
+          expectError: true,
+        });
+      }
+      return out;
+    }
+
+    const FIXTURES: Fixture[] = [
+      ...makePageFixtures(),
+      ...makeLayoutFixtures(),
+      ...makeOrphanFixtures(),
+      ...makeMissingFrameFixtures(),
+    ];
+
+    it(`fixture 합계가 50개를 초과한다 (현재: ${FIXTURES.length})`, () => {
+      expect(FIXTURES.length).toBeGreaterThanOrEqual(50);
+    });
+
+    it.each(FIXTURES)("$name", async (fixture) => {
+      const { runLegacyToCanonicalMigration } = await import("../migration");
+      const elements = [buildElement("el-x", fixture.ownership)];
+      const adapter = buildMockAdapter(elements, []);
+      const doc = buildDoc({
+        pageIds: fixture.docPages,
+        reusableFrameIds: fixture.docFrames,
+      });
+      const result = await runLegacyToCanonicalMigration(
+        adapter,
+        "proj-fixture",
+        { canonicalDoc: doc },
+      );
+      expect(result.transformations).toHaveLength(1);
+      expect(result.transformations[0]?.canonicalParentId).toBe(
+        fixture.expectedCanonicalParentId,
+      );
+      if (fixture.expectError) {
+        expect(result.errors.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/apps/builder/src/lib/db/migration.ts
+++ b/apps/builder/src/lib/db/migration.ts
@@ -1,0 +1,131 @@
+/**
+ * ADR-903 P3-E E-3 — runLegacyToCanonicalMigration (read-through dry-run)
+ *
+ * legacy ownership marker (`element.page_id` / `element.layout_id`) 를
+ * canonical parent ID 로 변환 계산하는 dry-run 함수. DB 무변경 — 변환 결과만
+ * 반환. 실제 elements.updateMany / meta.set 은 E-6 (write-through) 단계에서.
+ *
+ * 흐름:
+ * 1. `_meta.get(projectId)` 조회 — 이미 `composition-1.0` 이면 status=skipped
+ * 2. `createMigrationBackup()` 호출 — backupKey 획득
+ * 3. `elements.getAll()` 전수 로드
+ * 4. 각 element 의 ownership → `legacyOwnershipToCanonicalParent()` 적용
+ * 5. canonical parent 미존재 시 errors 에 추가 (orphan vs missing-frame 구분)
+ * 6. errors 비었으면 status=success, 아니면 status=failure (DB 미변경 유지)
+ *
+ * 회귀 위험: dry-run 이라 DB write 0. E-6 진입 전 50+ fixture round-trip 으로
+ * 변환 정합성 검증.
+ */
+
+import type { CompositionDocument } from "@composition/shared";
+import type { Element } from "../../types/core/store.types";
+import type { Layout } from "../../types/builder/layout.types";
+import type { MetaRecord } from "./types";
+import { legacyOwnershipToCanonicalParent } from "../../adapters/canonical";
+import { createMigrationBackup } from "./migrationBackup";
+
+export interface MigrationTransformation {
+  elementId: string;
+  page_id_was: string | null;
+  layout_id_was: string | null;
+  canonicalParentId: string | null;
+}
+
+export interface MigrationResult {
+  status: "skipped" | "success" | "failure";
+  reason?: string;
+  backupKey?: string;
+  transformations: MigrationTransformation[];
+  errors: string[];
+}
+
+/**
+ * runLegacyToCanonicalMigration 가 의존하는 adapter 의 minimal surface.
+ * IndexedDBAdapter 의 elements/layouts/meta 그룹에서 read 메서드만 사용.
+ */
+interface MigrationCapableAdapter {
+  elements: { getAll(): Promise<Element[]> };
+  layouts: { getAll(): Promise<Layout[]> };
+  meta: {
+    get(projectId: string): Promise<MetaRecord | null>;
+  };
+}
+
+export interface MigrationOptions {
+  canonicalDoc: CompositionDocument;
+  /**
+   * E-3 단계는 항상 dry-run (default true). E-6 에서 false 옵션 활성화.
+   */
+  dryRun?: boolean;
+}
+
+/**
+ * legacy → canonical-1.0 변환을 dry-run 으로 계산.
+ * @returns 변환 결과 + errors. DB 는 무변경.
+ */
+export async function runLegacyToCanonicalMigration(
+  adapter: MigrationCapableAdapter,
+  projectId: string,
+  options: MigrationOptions,
+): Promise<MigrationResult> {
+  const { canonicalDoc } = options;
+
+  // 1. Skip if already migrated
+  const existing = await adapter.meta.get(projectId);
+  if (existing?.schemaVersion === "composition-1.0") {
+    return {
+      status: "skipped",
+      reason: "already migrated to composition-1.0",
+      transformations: [],
+      errors: [],
+    };
+  }
+
+  // 2. Create backup (read-only — localStorage dump)
+  const backupKey = await createMigrationBackup(
+    adapter as unknown as Parameters<typeof createMigrationBackup>[0],
+    projectId,
+  );
+
+  // 3. Read all elements (no DB write)
+  const elements = await adapter.elements.getAll();
+
+  // 4. Compute transformations
+  const transformations: MigrationTransformation[] = [];
+  const errors: string[] = [];
+
+  for (const el of elements) {
+    const ownership = {
+      page_id: el.page_id ?? null,
+      layout_id: el.layout_id ?? null,
+    };
+    const canonicalParentId = legacyOwnershipToCanonicalParent(
+      ownership,
+      canonicalDoc,
+    );
+
+    transformations.push({
+      elementId: el.id,
+      page_id_was: ownership.page_id,
+      layout_id_was: ownership.layout_id,
+      canonicalParentId,
+    });
+
+    if (canonicalParentId === null) {
+      if (ownership.page_id == null && ownership.layout_id == null) {
+        errors.push(`orphan element ${el.id} (page_id=null, layout_id=null)`);
+      } else {
+        errors.push(
+          `canonical parent missing for element ${el.id} (page_id=${ownership.page_id}, layout_id=${ownership.layout_id})`,
+        );
+      }
+    }
+  }
+
+  return {
+    status: errors.length === 0 ? "success" : "failure",
+    backupKey,
+    transformations,
+    errors,
+  };
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [ADR-903 P3-D 모든 sub-phase land + Phase 3/4/5 plan 완비 — 세션 33] - 2026-04-26
 
-> 세션 32 마지막 entry (Phase D 시나리오 갱신, commit `b7aa5846`) 이후 — P3-D-5 6/6 step 종결 + P3-D-2 GREEN cherry-pick + Phase C 정합화 plan land + Phase C GREEN 구현 land + P3-E IndexedDB persistence plan land + P3-E E-1 RED + GREEN land + P3-E E-2 (createMigrationBackup) RED + GREEN land + 잔여 grep audit land + Phase 4 G4 cover 확증. **P3-D 모든 sub-phase (D-1~D-5) land 완료** + **P3-E E-1/E-2 GREEN 종결**. ADR-903 진행도 ~96% → ~99.6%.
+> 세션 32 마지막 entry (Phase D 시나리오 갱신, commit `b7aa5846`) 이후 — P3-D-5 6/6 step 종결 + P3-D-2 GREEN cherry-pick + Phase C 정합화 plan land + Phase C GREEN 구현 land + P3-E IndexedDB persistence plan land + P3-E E-1 RED + GREEN land + P3-E E-2 (createMigrationBackup) RED + GREEN land + P3-E E-3 (runLegacyToCanonicalMigration dry-run + 50+ fixture) RED + GREEN land + 잔여 grep audit land + Phase 4 G4 cover 확증. **P3-D 모든 sub-phase (D-1~D-5) land 완료** + **P3-E E-1/E-2/E-3 GREEN 종결**. ADR-903 진행도 ~96% → ~99.7%.
 
 ### Architecture
 
@@ -124,6 +124,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Why**: ADR-903 P3-E breakdown 의 E-1 sub-phase. read-only stub land (write-through 미포함) — E-2 backup / E-3 migration / E-4 entry 연결 / E-5 dev warning / E-6 write-through 후속. legacy ownership marker (`element.layout_id`) 의존을 단계적으로 제거하기 위한 첫 인프라.
   - 검증: `metaStore.test.ts` 5/5 GREEN + `usePageManager.canonical.test.ts` 6/6 GREEN (전 session GREEN 유지) + `pnpm type-check` PASS + apps/builder vitest 546 PASS / 4 pre-existing FAIL (회귀 0)
   - 위치: `apps/builder/src/lib/db/types.ts` (MetaRecord +12 LOC, meta 그룹 +6 LOC, getByLayout JSDoc +6 LOC) / `apps/builder/src/lib/db/indexedDB/adapter.ts` (DB_VERSION 1 LOC + \_meta store +5 LOC + meta 그룹 +24 LOC + getByLayout JSDoc +6 LOC)
+
+- **ADR-903 P3-E E-3 RED + GREEN — runLegacyToCanonicalMigration (dry-run + 50+ fixture)**:
+  - `apps/builder/src/lib/db/migration.ts` 신규 (~120 LOC) — `runLegacyToCanonicalMigration(adapter, projectId, { canonicalDoc, dryRun? }): Promise<MigrationResult>` 함수
+    - `MigrationResult` interface: `{ status: "skipped" | "success" | "failure", reason?, backupKey?, transformations[], errors[] }`
+    - `MigrationTransformation` interface: `{ elementId, page_id_was, layout_id_was, canonicalParentId }`
+    - 흐름: `_meta.get` → 이미 `composition-1.0` 이면 status=skipped / `createMigrationBackup` 호출 → backupKey / `elements.getAll()` 전수 로드 / 각 element 의 ownership → `legacyOwnershipToCanonicalParent(canonicalDoc)` 적용 / canonical parent 미존재 시 errors push (orphan vs missing-frame 구분)
+    - **dry-run only** — DB write 0건. 실제 elements.updateMany / meta.set 은 E-6 단계
+  - `apps/builder/src/lib/db/__tests__/migration.test.ts` 신규 (~310 LOC) — 60 it (RED → GREEN):
+    - **9 core contract**: export / skipped (composition-1.0) / dry-run write 0 / backup key 반환 / layout_id transformation / page_id transformation / orphan errors / missing frame errors / status success vs failure
+    - **1 fixture count assertion**: ≥50 fixture 보장
+    - **50 fixture round-trip** (`it.each`): 15 page + 15 layout + 10 orphan + 10 missing-frame
+    - vitest jsdom 환경 명시 + `vi.mock("../migrationBackup")` (createMigrationBackup spy)
+  - **Why**: P3-E breakdown 의 E-3 sub-phase. legacy → composition-1.0 변환 정합성을 50+ fixture 로 dry-run 검증한 후 E-6 (write-through) 진입 가능. dry-run 이라 회귀 위험 0
+  - 검증: `migration.test.ts` 60/60 GREEN (RED → GREEN 전환) + `pnpm type-check` PASS + apps/builder vitest 611 PASS / 4 pre-existing FAIL (회귀 0, baseline 551 → 611)
+  - 위치: `apps/builder/src/lib/db/migration.ts` (신규) + `apps/builder/src/lib/db/__tests__/migration.test.ts` (신규)
 
 - **ADR-903 P3-E E-2 RED + GREEN — createMigrationBackup (read-only localStorage backup)**:
   - `apps/builder/src/lib/db/migrationBackup.ts` 신규 (88 LOC) — `createMigrationBackup(adapter, projectId): Promise<string>` 함수


### PR DESCRIPTION
…ry-run + 50+ fixture

legacy ownership marker (page_id / layout_id) → canonical parent ID 변환을 dry-run 으로 계산하는 함수 + 50+ legacy fixture round-trip 검증.

migration.ts (131 LOC):
- MigrationResult interface: { status: "skipped" | "success" | "failure", reason?, backupKey?, transformations[], errors[] }
- MigrationTransformation: { elementId, page_id_was, layout_id_was, canonicalParentId }
- 흐름: meta.get → composition-1.0 이면 skipped / createMigrationBackup 호출 → backupKey / elements.getAll 전수 로드 / 각 element 의 ownership → legacyOwnershipToCanonicalParent(canonicalDoc) 적용 / orphan vs missing-frame 구분하여 errors push
- dry-run only — DB write 0. 실제 updateMany / meta.set 은 E-6 단계

migration.test.ts (416 LOC, 60 it RED → GREEN):
- 9 core contract: export / skipped / dry-run write 0 / backup key / layout_id+page_id transformations / orphan errors / missing-frame errors / success vs failure
- 50 fixture round-trip (it.each): 15 page + 15 layout + 10 orphan + 10 missing-frame = E-3 design 의 50+ legacy fixture 충족
- vitest jsdom env + vi.mock("../migrationBackup") spy

검증:
- migration.test.ts 60/60 GREEN (RED → GREEN 전환)
- pnpm type-check PASS (3/3)
- apps/builder vitest 611 PASS / 4 pre-existing FAIL (회귀 0, baseline 551 → 611)

E-4 entry 연결 / E-5 dev warning / E-6 write-through 후속.