### PR TITLE
feat(adr-903): P3-E E-5 RED + GREEN — getByLayout dev warning + utils…

### DIFF
--- a/apps/builder/src/lib/db/__tests__/getByLayoutDeprecation.test.ts
+++ b/apps/builder/src/lib/db/__tests__/getByLayoutDeprecation.test.ts
@@ -1,0 +1,68 @@
+/**
+ * ADR-903 P3-E E-5 — getByLayout dev warning + utils/ TODO 주석
+ *
+ * legacy column (`element.layout_id`) read-only 선언 단계. write 차단은 E-6
+ * 에서. 본 단계는:
+ * - `adapter.ts:getByLayout` 에 dev mode console.warn 추가 (deprecated 사용 추적)
+ * - `utils/urlGenerator.ts:219` 및 `utils/element/elementUtils.ts:44` 의
+ *   `layout_id` 참조에 `TODO(P3-E)` 주석 추가
+ *
+ * 회귀 위험 0 — 모두 source-pattern 검증 (실제 동작 변경 없음).
+ */
+
+import { describe, it, expect } from "vitest";
+
+describe("P3-E E-5: getByLayout dev warning + utils TODO", () => {
+  // Test 1: getByLayout 메서드 본문에 console.warn 호출이 존재
+  it("adapter.ts 의 getByLayout 본문에 console.warn 호출이 존재한다", async () => {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const filePath = path.resolve(__dirname, "../indexedDB/adapter.ts");
+    const source = await fs.readFile(filePath, "utf-8");
+    // getByLayout: async ... => { ... console.warn ... } 패턴
+    // getByLayout 시작부터 다음 메서드 (} ,\n)까지 캡처
+    const match = source.match(/getByLayout:\s*async[\s\S]+?^\s+\},\n/m);
+    expect(
+      match,
+      "getByLayout 메서드 추출 실패 — 시그니처 변경 시 본 test regex 동기화 필요",
+    ).not.toBeNull();
+    expect(match![0]).toMatch(/console\.warn/);
+  });
+
+  // Test 2: getByLayout 의 dev warning 이 dev/development 환경 분기 안에 존재
+  it("getByLayout dev warning 이 development 환경 분기 안에서만 활성화된다", async () => {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const filePath = path.resolve(__dirname, "../indexedDB/adapter.ts");
+    const source = await fs.readFile(filePath, "utf-8");
+    const match = source.match(/getByLayout:\s*async[\s\S]+?^\s+\},\n/m);
+    expect(match).not.toBeNull();
+    // process.env.NODE_ENV !== "production" 또는 === "development" 둘 다 OK
+    expect(match![0]).toMatch(
+      /process\.env\.NODE_ENV\s*(?:!==\s*["']production["']|===\s*["']development["'])/,
+    );
+  });
+
+  // Test 3: urlGenerator.ts L219 근처의 layout_id 참조에 TODO(P3-E) 주석
+  it("urlGenerator.ts 의 layout_id 참조 직전 또는 인접 라인에 TODO(P3-E) 주석이 있다", async () => {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const filePath = path.resolve(__dirname, "../../../utils/urlGenerator.ts");
+    const source = await fs.readFile(filePath, "utf-8");
+    // TODO(P3-E)... canonical 키워드 + 그 다음 200자 안에 page.layout_id 등장
+    expect(source).toMatch(/TODO\(P3-E\)[\s\S]{0,200}page\.layout_id/);
+  });
+
+  // Test 4: elementUtils.ts L44 근처의 layout_id 참조에 TODO(P3-E) 주석
+  it("elementUtils.ts 의 layout_id 참조 직전 또는 인접 라인에 TODO(P3-E) 주석이 있다", async () => {
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const filePath = path.resolve(
+      __dirname,
+      "../../../utils/element/elementUtils.ts",
+    );
+    const source = await fs.readFile(filePath, "utf-8");
+    // TODO(P3-E)... + 그 다음 200자 안에 el.layout_id 등장
+    expect(source).toMatch(/TODO\(P3-E\)[\s\S]{0,200}el\.layout_id/);
+  });
+});

--- a/apps/builder/src/lib/db/indexedDB/adapter.ts
+++ b/apps/builder/src/lib/db/indexedDB/adapter.ts
@@ -765,6 +765,14 @@ export class IndexedDBAdapter implements DatabaseAdapter {
      * (`element.layout_id`) 의존을 제거하기 위함.
      */
     getByLayout: async (layoutId: string): Promise<Element[]> => {
+      // ADR-903 P3-E E-5: deprecated 사용 추적 — dev mode 에서 console.warn 발생.
+      // E-6 (write-through 전환) 후 caller 들이 canonical parent 기반 조회로 마이그레이션
+      // 완료되면 본 메서드 자체를 제거.
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          `[IndexedDB] getByLayout(${layoutId}) — @deprecated ADR-903 P3-E. canonical parent 기반 조회 (selectCanonicalReusableFrames + allElements.filter) 사용 권장. migration script 호출 경로는 예외.`,
+        );
+      }
       console.log(`📥 [IndexedDB] getByLayout 호출: layoutId=${layoutId}`);
       const elements = await this.getAllByIndex<Element>(
         "elements",

--- a/apps/builder/src/utils/element/elementUtils.ts
+++ b/apps/builder/src/utils/element/elementUtils.ts
@@ -6,168 +6,176 @@
  * - Kept essential utility functions (generateId, findBodyElement, etc.)
  */
 
-import { Element } from '../../types/core/store.types';
+import { Element } from "../../types/core/store.types";
 
 // 통합 요소 관리 유틸리티
 export class ElementUtils {
-    /**
-     * Generate unique element ID using crypto.randomUUID()
-     */
-    static generateId(): string {
-        return crypto.randomUUID();
+  /**
+   * Generate unique element ID using crypto.randomUUID()
+   */
+  static generateId(): string {
+    return crypto.randomUUID();
+  }
+
+  /**
+   * Delay utility for async operations
+   */
+  static async delay(ms: number = 0): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Find the body element for a given page
+   * Used for automatically setting body as parent when parent_id is null
+   */
+  static findBodyElement(elements: Element[], pageId: string): string | null {
+    const bodyElement = elements.find(
+      (el) => el.page_id === pageId && el.tag === "body",
+    );
+    return bodyElement?.id || null;
+  }
+
+  /**
+   * Find the body element for a given layout
+   * Used for automatically setting body as parent when parent_id is null in Layout mode
+   */
+  static findLayoutBodyElement(
+    elements: Element[],
+    layoutId: string,
+  ): string | null {
+    // TODO(P3-E): canonical parent 기반으로 교체 — el.layout_id legacy
+    // ownership marker 사용. write-through 전환 (E-6) 후 reusable frame
+    // 의 children 검색으로 변경 예정.
+    const bodyElement = elements.find(
+      (el) => el.layout_id === layoutId && el.tag === "body",
+    );
+    return bodyElement?.id || null;
+  }
+
+  /**
+   * Find body element by context (page or layout)
+   * Automatically chooses the right method based on provided IDs
+   * @param elements - All elements
+   * @param pageId - Page ID (for page mode)
+   * @param layoutId - Layout ID (for layout mode)
+   * @returns Body element ID or null
+   */
+  static findBodyByContext(
+    elements: Element[],
+    pageId: string | null,
+    layoutId: string | null,
+  ): string | null {
+    // Layout mode takes priority
+    if (layoutId) {
+      return this.findLayoutBodyElement(elements, layoutId);
+    }
+    // Fall back to page mode
+    if (pageId) {
+      return this.findBodyElement(elements, pageId);
+    }
+    return null;
+  }
+
+  /**
+   * Migrate orphan elements (parent_id === null) to body element
+   * Excludes the body element itself
+   *
+   * @param elements - All elements
+   * @param pageId - Target page ID
+   * @returns Updated elements array and list of elements that need DB update
+   */
+  static migrateOrphanElementsToBody(
+    elements: Element[],
+    pageId: string,
+  ): { elements: Element[]; updatedElements: Element[] } {
+    const bodyElement = elements.find(
+      (el) => el.page_id === pageId && el.tag === "body",
+    );
+
+    if (!bodyElement) {
+      console.warn(`⚠️ Body 요소를 찾을 수 없습니다: pageId=${pageId}`);
+      return { elements, updatedElements: [] };
     }
 
-    /**
-     * Delay utility for async operations
-     */
-    static async delay(ms: number = 0): Promise<void> {
-        return new Promise(resolve => setTimeout(resolve, ms));
+    const orphanElements = elements.filter(
+      (el) =>
+        el.page_id === pageId && el.parent_id === null && el.tag !== "body",
+    );
+
+    if (orphanElements.length === 0) {
+      return { elements, updatedElements: [] };
     }
 
-    /**
-     * Find the body element for a given page
-     * Used for automatically setting body as parent when parent_id is null
-     */
-    static findBodyElement(elements: Element[], pageId: string): string | null {
-        const bodyElement = elements.find(
-            el => el.page_id === pageId && el.tag === 'body'
-        );
-        return bodyElement?.id || null;
+    console.log(`🔄 ${orphanElements.length}개의 고아 요소를 body로 이동:`, {
+      pageId,
+      bodyId: bodyElement.id,
+      orphanIds: orphanElements.map((el) => el.id),
+    });
+
+    // orphan 요소들의 parent_id를 body.id로 설정
+    const updatedElements = orphanElements.map((el) => ({
+      ...el,
+      parent_id: bodyElement.id,
+    }));
+
+    // 전체 요소 배열에서 업데이트된 요소들로 교체
+    const newElements = elements.map((el) => {
+      const updated = updatedElements.find((u) => u.id === el.id);
+      return updated || el;
+    });
+
+    return {
+      elements: newElements,
+      updatedElements,
+    };
+  }
+
+  /**
+   * Get all child elements recursively
+   */
+  static getDescendants(elements: Element[], parentId: string): Element[] {
+    const children = elements.filter((el) => el.parent_id === parentId);
+    const allDescendants = [...children];
+
+    children.forEach((child) => {
+      allDescendants.push(...this.getDescendants(elements, child.id));
+    });
+
+    return allDescendants;
+  }
+
+  /**
+   * Check if an element is ancestor of another element
+   */
+  static isAncestor(
+    elements: Element[],
+    ancestorId: string,
+    descendantId: string,
+  ): boolean {
+    let current = elements.find((el) => el.id === descendantId);
+
+    while (current) {
+      if (current.parent_id === ancestorId) {
+        return true;
+      }
+      current = elements.find((el) => el.id === current!.parent_id);
     }
 
-    /**
-     * Find the body element for a given layout
-     * Used for automatically setting body as parent when parent_id is null in Layout mode
-     */
-    static findLayoutBodyElement(elements: Element[], layoutId: string): string | null {
-        const bodyElement = elements.find(
-            el => el.layout_id === layoutId && el.tag === 'body'
-        );
-        return bodyElement?.id || null;
+    return false;
+  }
+
+  /**
+   * Get the path from root to element (breadcrumb)
+   */
+  static getElementPath(elements: Element[], elementId: string): Element[] {
+    const path: Element[] = [];
+    let current = elements.find((el) => el.id === elementId);
+
+    while (current) {
+      path.unshift(current);
+      current = elements.find((el) => el.id === current!.parent_id);
     }
 
-    /**
-     * Find body element by context (page or layout)
-     * Automatically chooses the right method based on provided IDs
-     * @param elements - All elements
-     * @param pageId - Page ID (for page mode)
-     * @param layoutId - Layout ID (for layout mode)
-     * @returns Body element ID or null
-     */
-    static findBodyByContext(
-        elements: Element[],
-        pageId: string | null,
-        layoutId: string | null
-    ): string | null {
-        // Layout mode takes priority
-        if (layoutId) {
-            return this.findLayoutBodyElement(elements, layoutId);
-        }
-        // Fall back to page mode
-        if (pageId) {
-            return this.findBodyElement(elements, pageId);
-        }
-        return null;
-    }
-
-    /**
-     * Migrate orphan elements (parent_id === null) to body element
-     * Excludes the body element itself
-     *
-     * @param elements - All elements
-     * @param pageId - Target page ID
-     * @returns Updated elements array and list of elements that need DB update
-     */
-    static migrateOrphanElementsToBody(
-        elements: Element[],
-        pageId: string
-    ): { elements: Element[]; updatedElements: Element[] } {
-        const bodyElement = elements.find(
-            el => el.page_id === pageId && el.tag === 'body'
-        );
-
-        if (!bodyElement) {
-            console.warn(`⚠️ Body 요소를 찾을 수 없습니다: pageId=${pageId}`);
-            return { elements, updatedElements: [] };
-        }
-
-        const orphanElements = elements.filter(
-            el =>
-                el.page_id === pageId &&
-                el.parent_id === null &&
-                el.tag !== 'body'
-        );
-
-        if (orphanElements.length === 0) {
-            return { elements, updatedElements: [] };
-        }
-
-        console.log(`🔄 ${orphanElements.length}개의 고아 요소를 body로 이동:`, {
-            pageId,
-            bodyId: bodyElement.id,
-            orphanIds: orphanElements.map(el => el.id)
-        });
-
-        // orphan 요소들의 parent_id를 body.id로 설정
-        const updatedElements = orphanElements.map(el => ({
-            ...el,
-            parent_id: bodyElement.id
-        }));
-
-        // 전체 요소 배열에서 업데이트된 요소들로 교체
-        const newElements = elements.map(el => {
-            const updated = updatedElements.find(u => u.id === el.id);
-            return updated || el;
-        });
-
-        return {
-            elements: newElements,
-            updatedElements
-        };
-    }
-
-    /**
-     * Get all child elements recursively
-     */
-    static getDescendants(elements: Element[], parentId: string): Element[] {
-        const children = elements.filter(el => el.parent_id === parentId);
-        const allDescendants = [...children];
-
-        children.forEach(child => {
-            allDescendants.push(...this.getDescendants(elements, child.id));
-        });
-
-        return allDescendants;
-    }
-
-    /**
-     * Check if an element is ancestor of another element
-     */
-    static isAncestor(elements: Element[], ancestorId: string, descendantId: string): boolean {
-        let current = elements.find(el => el.id === descendantId);
-
-        while (current) {
-            if (current.parent_id === ancestorId) {
-                return true;
-            }
-            current = elements.find(el => el.id === current!.parent_id);
-        }
-
-        return false;
-    }
-
-    /**
-     * Get the path from root to element (breadcrumb)
-     */
-    static getElementPath(elements: Element[], elementId: string): Element[] {
-        const path: Element[] = [];
-        let current = elements.find(el => el.id === elementId);
-
-        while (current) {
-            path.unshift(current);
-            current = elements.find(el => el.id === current!.parent_id);
-        }
-
-        return path;
-    }
+    return path;
+  }
 }

--- a/apps/builder/src/utils/urlGenerator.ts
+++ b/apps/builder/src/utils/urlGenerator.ts
@@ -10,8 +10,8 @@
  * 4. 그 외 → "/" + Page.slug
  */
 
-import type { Page } from '../types/builder/unified.types';
-import type { Layout } from '../types/builder/layout.types';
+import type { Page } from "../types/builder/unified.types";
+import type { Layout } from "../types/builder/layout.types";
 
 // ============================================
 // Types
@@ -58,9 +58,13 @@ interface GeneratePageUrlParams {
  * })
  * // → '/products/shoes/nike'
  */
-export function generatePageUrl({ page, layout, allPages }: GeneratePageUrlParams): string {
+export function generatePageUrl({
+  page,
+  layout,
+  allPages,
+}: GeneratePageUrlParams): string {
   // 1. 절대 경로인 경우 그대로 반환
-  if (page.slug.startsWith('/')) {
+  if (page.slug.startsWith("/")) {
     return page.slug;
   }
 
@@ -91,10 +95,10 @@ export function generatePageUrl({ page, layout, allPages }: GeneratePageUrlParam
  */
 function buildParentPath(parentId: string, allPages: Page[]): string {
   const parent = allPages.find((p) => p.id === parentId);
-  if (!parent) return '';
+  if (!parent) return "";
 
   // 부모가 절대 경로면 그대로 반환
-  if (parent.slug.startsWith('/')) {
+  if (parent.slug.startsWith("/")) {
     return parent.slug;
   }
 
@@ -112,7 +116,7 @@ function buildParentPath(parentId: string, allPages: Page[]): string {
  * @param url - 정규화할 URL
  */
 function normalizeUrl(url: string): string {
-  return url.replace(/\/+/g, '/');
+  return url.replace(/\/+/g, "/");
 }
 
 // ============================================
@@ -140,7 +144,7 @@ function normalizeUrl(url: string): string {
 export function hasCircularReference(
   pageId: string,
   newParentId: string | null,
-  allPages: Page[]
+  allPages: Page[],
 ): boolean {
   if (!newParentId) return false;
 
@@ -211,12 +215,17 @@ export function findUrlConflict(
   newUrl: string,
   allPages: Page[],
   layouts: Layout[] = [],
-  excludePageId?: string
+  excludePageId?: string,
 ): Page | null {
   for (const page of allPages) {
     if (excludePageId && page.id === excludePageId) continue;
 
-    const layout = page.layout_id ? layouts.find((l) => l.id === page.layout_id) : null;
+    // TODO(P3-E): canonical parent 기반으로 교체 — page.layout_id legacy
+    // ownership marker 사용. write-through 전환 (E-6) 후 canonical document
+    // 의 reusable frame ID 매핑으로 변경 예정.
+    const layout = page.layout_id
+      ? layouts.find((l) => l.id === page.layout_id)
+      : null;
     const existingUrl = generatePageUrl({ page, layout, allPages });
 
     if (existingUrl === newUrl) {
@@ -291,7 +300,7 @@ export function convertToRouterPath(slug: string): string {
  */
 export function fillDynamicParams(
   slug: string,
-  params: Record<string, string>
+  params: Record<string, string>,
 ): string {
   let result = slug;
 
@@ -331,14 +340,17 @@ export function hasDynamicParams(slug: string): boolean {
  */
 export function matchDynamicUrl(
   pattern: string,
-  url: string
+  url: string,
 ): Record<string, string> | null {
   // 패턴을 정규식으로 변환
   const paramNames: string[] = [];
-  const regexPattern = pattern.replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, (_, name) => {
-    paramNames.push(name);
-    return '([^/]+)';
-  });
+  const regexPattern = pattern.replace(
+    /:([a-zA-Z_][a-zA-Z0-9_]*)/g,
+    (_, name) => {
+      paramNames.push(name);
+      return "([^/]+)";
+    },
+  );
 
   const regex = new RegExp(`^${regexPattern}$`);
   const match = url.match(regex);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [ADR-903 P3-D 모든 sub-phase land + Phase 3/4/5 plan 완비 — 세션 33] - 2026-04-26
 
-> 세션 32 마지막 entry (Phase D 시나리오 갱신, commit `b7aa5846`) 이후 — P3-D-5 6/6 step 종결 + P3-D-2 GREEN cherry-pick + Phase C 정합화 plan land + Phase C GREEN 구현 land + P3-E IndexedDB persistence plan land + P3-E E-1 RED + GREEN land + P3-E E-2 (createMigrationBackup) RED + GREEN land + 잔여 grep audit land + Phase 4 G4 cover 확증. **P3-D 모든 sub-phase (D-1~D-5) land 완료** + **P3-E E-1/E-2 GREEN 종결**. ADR-903 진행도 ~96% → ~99.6%.
+> 세션 32 마지막 entry (Phase D 시나리오 갱신, commit `b7aa5846`) 이후 — P3-D-5 6/6 step 종결 + P3-D-2 GREEN cherry-pick + Phase C 정합화 plan land + Phase C GREEN 구현 land + P3-E IndexedDB persistence plan land + P3-E E-1 RED + GREEN land + P3-E E-2 (createMigrationBackup) RED + GREEN land + P3-E E-5 (getByLayout dev warning + utils TODO) RED + GREEN land + 잔여 grep audit land + Phase 4 G4 cover 확증. **P3-D 모든 sub-phase (D-1~D-5) land 완료** + **P3-E E-1/E-2/E-5 GREEN 종결** (E-3/E-4 별도 PR). ADR-903 진행도 ~96% → ~99.7%.
 
 ### Architecture
 
@@ -124,6 +124,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Why**: ADR-903 P3-E breakdown 의 E-1 sub-phase. read-only stub land (write-through 미포함) — E-2 backup / E-3 migration / E-4 entry 연결 / E-5 dev warning / E-6 write-through 후속. legacy ownership marker (`element.layout_id`) 의존을 단계적으로 제거하기 위한 첫 인프라.
   - 검증: `metaStore.test.ts` 5/5 GREEN + `usePageManager.canonical.test.ts` 6/6 GREEN (전 session GREEN 유지) + `pnpm type-check` PASS + apps/builder vitest 546 PASS / 4 pre-existing FAIL (회귀 0)
   - 위치: `apps/builder/src/lib/db/types.ts` (MetaRecord +12 LOC, meta 그룹 +6 LOC, getByLayout JSDoc +6 LOC) / `apps/builder/src/lib/db/indexedDB/adapter.ts` (DB_VERSION 1 LOC + \_meta store +5 LOC + meta 그룹 +24 LOC + getByLayout JSDoc +6 LOC)
+
+- **ADR-903 P3-E E-5 RED + GREEN — getByLayout dev warning + utils TODO 주석** (회귀 위험 0):
+  - `apps/builder/src/lib/db/indexedDB/adapter.ts` — `getByLayout` 메서드 본문에 `process.env.NODE_ENV !== "production"` 분기 + `console.warn` 호출 추가 (deprecated 사용 추적, dev mode 한정)
+  - `apps/builder/src/utils/urlGenerator.ts:219` — `page.layout_id` 참조 직전 `// TODO(P3-E): canonical parent 기반으로 교체 ...` 주석 (write-through 전환 E-6 후 canonical document 의 reusable frame ID 매핑으로 변경 예정)
+  - `apps/builder/src/utils/element/elementUtils.ts:44` — `el.layout_id === layoutId` 참조 직전 동일 TODO 주석
+  - `apps/builder/src/lib/db/__tests__/getByLayoutDeprecation.test.ts` 신규 — 4 it RED → GREEN: getByLayout console.warn 존재 / dev 환경 분기 / urlGenerator TODO / elementUtils TODO (source-pattern 검증)
+  - **Why**: P3-E breakdown 의 E-5 sub-phase. legacy column read-only 선언 + write 차단 준비. dev-only warning 으로 caller 가 점진적으로 canonical parent 조회로 마이그레이션할 수 있도록 추적 가능. utils/ TODO 는 E-6 전환 시점의 작업 인덱스
+  - 검증: `getByLayoutDeprecation.test.ts` 4/4 GREEN (RED → GREEN 전환) + `pnpm type-check` PASS + apps/builder vitest 615 PASS / 4 pre-existing FAIL (회귀 0)
+  - 위치: `apps/builder/src/lib/db/indexedDB/adapter.ts` (getByLayout +9 LOC) / `apps/builder/src/utils/urlGenerator.ts` (TODO +3 LOC) / `apps/builder/src/utils/element/elementUtils.ts` (TODO +3 LOC) / `apps/builder/src/lib/db/__tests__/getByLayoutDeprecation.test.ts` (신규 ~75 LOC)
 
 - **ADR-903 P3-E E-2 RED + GREEN — createMigrationBackup (read-only localStorage backup)**:
   - `apps/builder/src/lib/db/migrationBackup.ts` 신규 (88 LOC) — `createMigrationBackup(adapter, projectId): Promise<string>` 함수


### PR DESCRIPTION
…/ TODO 주석

ADR-903 P3-E E-5 sub-phase. legacy column read-only 선언 단계 — write 차단은 E-6.

- adapter.ts:getByLayout 본문에 process.env.NODE_ENV !== "production" 분기 + console.warn 호출 추가 (deprecated 사용 추적, dev mode 한정)
- urlGenerator.ts:219 의 page.layout_id 참조 직전 TODO(P3-E) 주석
- elementUtils.ts:44 의 el.layout_id 참조 직전 TODO(P3-E) 주석
- getByLayoutDeprecation.test.ts 신규 — 4 it RED → GREEN: console.warn 존재 / dev 환경 분기 / urlGenerator TODO / elementUtils TODO (source-pattern 검증)

검증:
- getByLayoutDeprecation.test.ts 4/4 GREEN (RED → GREEN 전환)
- pnpm type-check PASS (3/3)
- apps/builder vitest 615 PASS / 4 pre-existing FAIL (회귀 0)

Note: elementUtils.ts / urlGenerator.ts 의 line count 변화량은 prettier hook auto-reformat (4-space → 2-space indent + single → double quote) 포함. 실제 의미 있는 변경은 TODO 주석 3줄 + 분기 1개. PR review 시 indent diff 무시.

E-3 (migration script) / E-4 (entry 연결) / E-6 (write-through) 후속.