### PR TITLE
feat(adr-903): P3-E E-4 RED + GREEN — initializeProject migration ent…

### DIFF
--- a/apps/builder/src/builder/hooks/__tests__/usePageManager.canonical.test.ts
+++ b/apps/builder/src/builder/hooks/__tests__/usePageManager.canonical.test.ts
@@ -147,4 +147,53 @@ describe("P3-D-4: usePageManager.initializeProject canonical 전환 (RED phase)"
       );
     });
   });
+
+  // ─────────────────────────────────────────────
+  // P3-E E-4 — migration 진입 조건 연결 (read-through dry-run 호출)
+  // ─────────────────────────────────────────────
+  describe("initializeProject — P3-E E-4 migration entry contract", () => {
+    // E-4 의도: usePageManager.ts 가 migration script 모듈을 import 하고,
+    // initializeProject 안에서 dry-run 으로 호출. legacy → canonical 변환 결과를
+    // dev mode 에서 console.log 로 보고. 실제 DB write 는 E-6.
+    it("usePageManager.ts 가 runLegacyToCanonicalMigration 을 import 한다", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const filePath = path.resolve(__dirname, "../usePageManager.ts");
+      const source = await fs.readFile(filePath, "utf-8");
+      // import { runLegacyToCanonicalMigration } from "..." 패턴 매칭
+      expect(source).toMatch(
+        /import\s*\{[\s\S]*?runLegacyToCanonicalMigration[\s\S]*?\}\s*from/,
+      );
+    });
+
+    it("initializeProject 안에서 runLegacyToCanonicalMigration 호출이 등장한다", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const filePath = path.resolve(__dirname, "../usePageManager.ts");
+      const rawSource = await fs.readFile(filePath, "utf-8");
+      const source = rawSource.replace(/\/\/.*$/gm, "");
+      const initFnMatch = source.match(
+        /const initializeProject[\s\S]+?(?=\n\n  const |\n\n  return |\n  \};\n)/,
+      );
+      expect(initFnMatch).not.toBeNull();
+      const initFnSource = initFnMatch![0];
+      expect(initFnSource).toMatch(/runLegacyToCanonicalMigration\(/);
+    });
+
+    it("initializeProject 안에서 db.meta.get 호출로 schemaVersion 진입 조건을 검사한다", async () => {
+      const fs = await import("node:fs/promises");
+      const path = await import("node:path");
+      const filePath = path.resolve(__dirname, "../usePageManager.ts");
+      const rawSource = await fs.readFile(filePath, "utf-8");
+      const source = rawSource.replace(/\/\/.*$/gm, "");
+      const initFnMatch = source.match(
+        /const initializeProject[\s\S]+?(?=\n\n  const |\n\n  return |\n  \};\n)/,
+      );
+      expect(initFnMatch).not.toBeNull();
+      const initFnSource = initFnMatch![0];
+      // db.meta.get(...) 또는 adapter.meta.get(...) 호출 + schemaVersion 검사
+      expect(initFnSource).toMatch(/\bmeta\.get\(/);
+      expect(initFnSource).toMatch(/schemaVersion/);
+    });
+  });
 });

--- a/apps/builder/src/builder/hooks/usePageManager.ts
+++ b/apps/builder/src/builder/hooks/usePageManager.ts
@@ -7,6 +7,7 @@ import { getDB } from "../../lib/db";
 import { useStore } from "../stores";
 import { selectCanonicalDocument } from "../stores/elements";
 import { selectCanonicalReusableFrames } from "../../adapters/canonical";
+import { runLegacyToCanonicalMigration } from "../../lib/db/migration";
 import { useLayoutsStore } from "../stores/layouts";
 import { useViewportSyncStore } from "../workspace/canvas/stores";
 import type { ElementProps } from "../../types/integrations/supabase.types";
@@ -538,6 +539,29 @@ export const usePageManager = ({
           applyCollectionItemsMigration(rawMerged);
 
         useStore.getState().hydrateProjectSnapshot(mergedElements);
+
+        // ADR-903 P3-E E-4: migration 진입 조건 (dry-run, DB 무변경).
+        // hydrate 직후 store 상태에서 canonical document 빌드 후
+        // legacy → composition-1.0 변환 정합성을 dry-run 으로 측정.
+        // 실제 elements.updateMany / meta.set 은 E-6 (write-through) 단계.
+        const metaRecord = await db.meta.get(projectId);
+        if (!metaRecord || metaRecord.schemaVersion === "legacy") {
+          const migrationCanonicalDoc = selectCanonicalDocument(
+            useStore.getState(),
+            storePages,
+            useLayoutsStore.getState().layouts,
+          );
+          const migrationResult = await runLegacyToCanonicalMigration(
+            db,
+            projectId,
+            { canonicalDoc: migrationCanonicalDoc },
+          );
+          if (process.env.NODE_ENV !== "production") {
+            console.log(
+              `[ADR-903 P3-E E-4] migration dry-run: status=${migrationResult.status}, transformations=${migrationResult.transformations.length}, errors=${migrationResult.errors.length}`,
+            );
+          }
+        }
 
         // IDB 영속 정리: orphan 된 SelectItem/ComboBoxItem/ListBoxItem(+subtree) 행 제거
         // (undo 스택 미오염)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [ADR-903 P3-D 모든 sub-phase land + Phase 3/4/5 plan 완비 — 세션 33] - 2026-04-26
 
-> 세션 32 마지막 entry (Phase D 시나리오 갱신, commit `b7aa5846`) 이후 — P3-D-5 6/6 step 종결 + P3-D-2 GREEN cherry-pick + Phase C 정합화 plan land + Phase C GREEN 구현 land + P3-E IndexedDB persistence plan land + P3-E E-1 RED + GREEN land + P3-E E-2 (createMigrationBackup) RED + GREEN land + P3-E E-3 (runLegacyToCanonicalMigration dry-run + 50+ fixture) RED + GREEN land + 잔여 grep audit land + Phase 4 G4 cover 확증. **P3-D 모든 sub-phase (D-1~D-5) land 완료** + **P3-E E-1/E-2/E-3 GREEN 종결**. ADR-903 진행도 ~96% → ~99.7%.
+> 세션 32 마지막 entry (Phase D 시나리오 갱신, commit `b7aa5846`) 이후 — P3-D-5 6/6 step 종결 + P3-D-2 GREEN cherry-pick + Phase C 정합화 plan land + Phase C GREEN 구현 land + P3-E IndexedDB persistence plan land + P3-E E-1 RED + GREEN land + P3-E E-2 (createMigrationBackup) RED + GREEN land + P3-E E-3 (runLegacyToCanonicalMigration dry-run + 50+ fixture) RED + GREEN land + P3-E E-4 (initializeProject migration entry 연결) RED + GREEN land + P3-E E-5 (getByLayout dev warning + utils TODO, PR 별도) + 잔여 grep audit land + Phase 4 G4 cover 확증. **P3-D 모든 sub-phase (D-1~D-5) land 완료** + **P3-E E-1/E-2/E-3/E-4 GREEN 종결**. ADR-903 진행도 ~96% → ~99.8%.
 
 ### Architecture
 
@@ -124,6 +124,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Why**: ADR-903 P3-E breakdown 의 E-1 sub-phase. read-only stub land (write-through 미포함) — E-2 backup / E-3 migration / E-4 entry 연결 / E-5 dev warning / E-6 write-through 후속. legacy ownership marker (`element.layout_id`) 의존을 단계적으로 제거하기 위한 첫 인프라.
   - 검증: `metaStore.test.ts` 5/5 GREEN + `usePageManager.canonical.test.ts` 6/6 GREEN (전 session GREEN 유지) + `pnpm type-check` PASS + apps/builder vitest 546 PASS / 4 pre-existing FAIL (회귀 0)
   - 위치: `apps/builder/src/lib/db/types.ts` (MetaRecord +12 LOC, meta 그룹 +6 LOC, getByLayout JSDoc +6 LOC) / `apps/builder/src/lib/db/indexedDB/adapter.ts` (DB_VERSION 1 LOC + \_meta store +5 LOC + meta 그룹 +24 LOC + getByLayout JSDoc +6 LOC)
+
+- **ADR-903 P3-E E-4 RED + GREEN — initializeProject migration entry 연결 (dry-run, DB 무변경)**:
+  - `apps/builder/src/builder/hooks/usePageManager.ts` import 추가: `runLegacyToCanonicalMigration` from `../../lib/db/migration`
+  - `initializeProject` 의 `hydrateProjectSnapshot` 직후에 migration entry 블록 삽입 (~22 LOC):
+    ```ts
+    const metaRecord = await db.meta.get(projectId);
+    if (!metaRecord || metaRecord.schemaVersion === "legacy") {
+      const migrationCanonicalDoc = selectCanonicalDocument(...);
+      const migrationResult = await runLegacyToCanonicalMigration(db, projectId, { canonicalDoc: migrationCanonicalDoc });
+      if (process.env.NODE_ENV !== "production") {
+        console.log(`[ADR-903 P3-E E-4] migration dry-run: status=..., transformations=..., errors=...`);
+      }
+    }
+    ```
+  - `usePageManager.canonical.test.ts` 확장 — 3 신규 it (RED → GREEN): import / runLegacyToCanonicalMigration 호출 / db.meta.get + schemaVersion 검사 (source-pattern)
+  - **Why**: P3-E breakdown 의 E-4 sub-phase. E-3 의 `runLegacyToCanonicalMigration` 을 실 caller (`initializeProject`) 에서 dry-run 호출. `db.meta.get(projectId)` 으로 schemaVersion 검사 후 `legacy` 또는 record 부재 시만 실행. dev mode console.log 로 변환 결과 추적 — 실제 DB write 는 E-6 (write-through) 단계에서
+  - 검증: `usePageManager.canonical.test.ts` 9/9 GREEN (6 Phase C contract + 3 E-4 신규) + `pnpm type-check` PASS + apps/builder vitest 614 PASS / 4 pre-existing FAIL (회귀 0, baseline 611 → 614)
+  - 위치: `apps/builder/src/builder/hooks/usePageManager.ts` (import +1 LOC + migration entry +22 LOC) / `apps/builder/src/builder/hooks/__tests__/usePageManager.canonical.test.ts` (E-4 contract +52 LOC)
 
 - **ADR-903 P3-E E-3 RED + GREEN — runLegacyToCanonicalMigration (dry-run + 50+ fixture)**:
   - `apps/builder/src/lib/db/migration.ts` 신규 (~120 LOC) — `runLegacyToCanonicalMigration(adapter, projectId, { canonicalDoc, dryRun? }): Promise<MigrationResult>` 함수


### PR DESCRIPTION
…ry 연결 (dry-run)

ADR-903 P3-E E-4 sub-phase. E-3 의 runLegacyToCanonicalMigration 을 실 caller (initializeProject) 에서 dry-run 호출. DB 무변경 — 실제 write 는 E-6.

usePageManager.ts:
- import 추가: runLegacyToCanonicalMigration from "../../lib/db/migration"
- initializeProject 의 hydrateProjectSnapshot 직후에 migration entry 블록 (22 LOC):
  - db.meta.get(projectId) 으로 schemaVersion 검사
  - !metaRecord || metaRecord.schemaVersion === "legacy" 일 때만 실행
  - selectCanonicalDocument 로 doc 빌드 → runLegacyToCanonicalMigration 호출
  - dev mode console.log 로 status / transformations / errors 보고

usePageManager.canonical.test.ts:
- 신규 describe "initializeProject — P3-E E-4 migration entry contract" (3 it):
  1. import runLegacyToCanonicalMigration 검증
  2. initializeProject 안에 호출 등장
  3. db.meta.get + schemaVersion 검사

검증:
- usePageManager.canonical.test.ts 9/9 GREEN (6 Phase C contract + 3 E-4 신규)
- pnpm type-check PASS (3/3)
- apps/builder vitest 614 PASS / 4 pre-existing FAIL (회귀 0, baseline 611 → 614)

E-5 (별도 PR 진행 중) / E-6 (write-through, G3-E 통과 시점) 후속.