### PR TITLE
feat(adr-911-p2-b): FramesTab consumer → frameActions 위임 (functional 동등)

### DIFF
--- a/apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx
+++ b/apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx
@@ -28,12 +28,16 @@ import {
   useLayoutsStore,
   useSelectedReusableFrameId,
 } from "../../../stores/layouts";
+import {
+  createReusableFrame,
+  deleteReusableFrame,
+  selectReusableFrame,
+} from "../../../stores/utils/frameActions";
 import { useEditModeStore } from "../../../stores/editMode";
 import { useStore } from "../../../stores";
 import { ElementProps } from "../../../../types/integrations/supabase.types";
 import { Element } from "../../../../types/core/store.types";
 import type { ElementTreeItem } from "../../../../types/builder/stately.types";
-import type { Layout } from "../../../../types/builder/layout.types";
 import { buildTreeFromElements } from "../../../utils/treeUtils";
 import { MessageService } from "../../../../utils/messaging";
 import { getDB } from "../../../../lib/db";
@@ -64,13 +68,10 @@ export function FramesTab({
   // P3-B canonical selector: selectedReusableFrameId (currentLayoutId alias 제거됨)
   const selectedReusableFrameId = useSelectedReusableFrameId();
 
-  // Legacy bridge — P3-D에서 canonical document mutation으로 교체 예정
+  // Legacy read bridge — frame 목록은 useLayoutsStore.layouts[] 직접 소비.
+  // PR-C 에서 selectCanonicalDocument 기반 read path 로 전환 예정.
+  // CRUD 는 ADR-911 P2-a frameActions wrapper (PR-A) 로 위임.
   const layouts = useLayoutsStore((state) => state.layouts);
-  const setCurrentLayoutInStore = useLayoutsStore(
-    (state) => state.setCurrentLayout,
-  );
-  const createLayout = useLayoutsStore((state) => state.createLayout);
-  const deleteLayout = useLayoutsStore((state) => state.deleteLayout);
   const fetchLayouts = useLayoutsStore((state) => state.fetchLayouts);
 
   // selectedReusableFrameId 기반 현재 프레임 조회 (legacy bridge)
@@ -337,74 +338,63 @@ export function FramesTab({
     [expandedKeys, toggleKey, selectedElementId, currentFrame?.id],
   );
 
-  // Frame 선택 핸들러
+  // Frame 선택 핸들러 — id 기반 (ADR-911 P2-a PR-B)
   const handleSelectFrame = useCallback(
-    async (frame: Layout) => {
+    async (frameId: string) => {
       try {
         const db = await getDB();
         // ADR-903 P3-D 진입 전: getByLayout bridge 유지
-        const frameElements = await db.elements.getByLayout(frame.id);
+        const frameElements = await db.elements.getByLayout(frameId);
 
         mergeElements(frameElements);
-        loadedFrameIdsRef.current.add(frame.id);
+        loadedFrameIdsRef.current.add(frameId);
 
-        // P3-B: setCurrentLayout → selectedReusableFrameId 업데이트
-        setCurrentLayoutInStore(frame.id);
-        setEditModeLayoutId(frame.id);
+        selectReusableFrame(frameId);
+        setEditModeLayoutId(frameId);
       } catch (error) {
         console.error("[FramesTab] Frame 선택 에러:", error);
-        setCurrentLayoutInStore(frame.id);
-        setEditModeLayoutId(frame.id);
+        selectReusableFrame(frameId);
+        setEditModeLayoutId(frameId);
       }
     },
-    [setCurrentLayoutInStore, setEditModeLayoutId, mergeElements],
+    [setEditModeLayoutId, mergeElements],
   );
 
-  // Frame 삭제 핸들러
+  // Frame 삭제 핸들러 — frameActions.deleteReusableFrame 위임
   const handleDeleteFrame = useCallback(
-    async (frame: Layout) => {
+    async (frameId: string) => {
       try {
-        await deleteLayout(frame.id);
-        const remaining = layouts.filter((l) => l.id !== frame.id);
+        await deleteReusableFrame(frameId);
+        const remaining = layouts.filter((l) => l.id !== frameId);
         if (remaining.length > 0) {
-          handleSelectFrame(remaining[0]);
+          handleSelectFrame(remaining[0].id);
         } else {
-          setCurrentLayoutInStore(null);
+          selectReusableFrame(null);
           setEditModeLayoutId(null);
         }
       } catch (error) {
         console.error("[FramesTab] Frame 삭제 에러:", error);
       }
     },
-    [
-      deleteLayout,
-      layouts,
-      handleSelectFrame,
-      setCurrentLayoutInStore,
-      setEditModeLayoutId,
-    ],
+    [layouts, handleSelectFrame, setEditModeLayoutId],
   );
 
-  // 새 Frame 생성 핸들러
+  // 새 Frame 생성 핸들러 — frameActions.createReusableFrame 위임
   const handleAddFrame = useCallback(async () => {
     if (!projectId) {
       console.error("[FramesTab] 프로젝트 ID가 없습니다");
       return;
     }
     try {
-      // ADR-903 P3-D 진입 전: createLayout bridge 유지
-      const newFrame = await createLayout({
+      const ref = await createReusableFrame({
         name: `Frame ${layouts.length + 1}`,
-        description: "",
-        project_id: projectId,
+        projectId,
       });
-      if (newFrame) {
-        handleSelectFrame(newFrame);
-      }
+      handleSelectFrame(ref.id);
     } catch (error) {
       console.error("[FramesTab] Frame 생성 에러:", error);
     }
-  }, [projectId, createLayout, layouts.length, handleSelectFrame]);
+  }, [projectId, layouts.length, handleSelectFrame]);
 
   // Element 삭제 핸들러
   const handleDeleteElement = useCallback(
@@ -454,7 +444,7 @@ export function FramesTab({
               <div
                 key={frame.id}
                 className="element"
-                onClick={() => handleSelectFrame(frame)}
+                onClick={() => handleSelectFrame(frame.id)}
               >
                 <div
                   className={`elementItem ${
@@ -480,7 +470,7 @@ export function FramesTab({
                       aria-label={`Delete ${frame.name}`}
                       onClick={(e) => {
                         e.stopPropagation();
-                        handleDeleteFrame(frame);
+                        handleDeleteFrame(frame.id);
                       }}
                     >
                       <Trash

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ADR-911 Phase 2 PR-B — FramesTab consumer → frameActions 위임 — 세션 37 후반] - 2026-04-27
+
+### Architecture
+
+- **ADR-911 Phase 2 PR-B — FramesTab.tsx 가 frameActions wrapper 위임으로 전환** (functional 동등):
+  - `handleAddFrame` → `createReusableFrame({ name, projectId })` 호출
+  - `handleDeleteFrame` → `deleteReusableFrame(frameId)` 호출
+  - `handleSelectFrame` → `selectReusableFrame(frameId)` 호출 (legacy `setCurrentLayout` 직접 destructure 제거)
+  - 핸들러 시그니처 단순화: `(frame: Layout)` → `(frameId: string)` — 내부 정합화 (`frame.id` 만 사용하던 패턴 명시)
+  - 제거: `Layout` 타입 import / `useLayoutsStore` 의 `setCurrentLayout` / `createLayout` / `deleteLayout` 직접 destructure
+  - 유지: `useLayoutsStore.layouts[]` read (PR-C 에서 canonical 전환 예정) / `fetchLayouts` mount effect / `useSelectedReusableFrameId`
+  - **Why**: PR-A 에서 도입한 frameActions wrapper 의 첫 consumer 실증. legacy bridge 호출은 wrapper 내부로 격리 → P3 cascade 재작성 시 단일 진입점만 변경하면 됨
+  - 검증: type-check 0 / FramesTab 자체 vitest 부재 → PR-A frameActions 7/7 vitest 가 wrapper 행위 보장 (functional 동등)
+  - 위치: `apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx`
+
+### Documentation
+
+- **ADR-911 진행 로그 + sub-PR 분할 표 갱신**:
+  - `docs/adr/911-layout-frameset-pencil-redesign.md` 진행 로그에 PR-B entry 추가 (handler 시그니처 변경 명시)
+  - `docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md` PR-B 상태 `후속 세션` → `✅ 2026-04-27 (PR pending)`
+
 ## [ADR-911 Phase 2 PR-A — frameActions canonical wrapper + FRAMES_TAB_CANONICAL flag — 세션 37 후반] - 2026-04-27
 
 ### Architecture

--- a/docs/adr/911-layout-frameset-pencil-redesign.md
+++ b/docs/adr/911-layout-frameset-pencil-redesign.md
@@ -8,12 +8,18 @@ In Progress — 2026-04-26 → 2026-04-27
 
 - **2026-04-26 (세션 35)**: Proposed. Phase 0 ~ 4 sub-budget 작성, design breakdown 발행 (843줄)
 - **2026-04-27 (세션 36)**: Phase 1 함수 layer 완결 — `convertTemplateToCanonicalFrame` / `flattenTemplateElements` / `buildDescendantsFromSlots` / `hoistLayoutAsReusableFrame` / `dryRunMigrationP911` / `applyMigrationP911` (vitest 45/45 PASS, commits batch in PR #249 + `f4047af1`)
-- **2026-04-27 (세션 37)**: Phase 2 진입 — **PR-A: frameActions canonical wrapper + FRAMES_TAB_CANONICAL feature flag**
+- **2026-04-27 (세션 37)**: Phase 2 진입 — **PR-A: frameActions canonical wrapper + FRAMES_TAB_CANONICAL feature flag** (commit `e9e388ca`)
   - `apps/builder/src/builder/stores/utils/frameActions.ts` 신규 — `createReusableFrame` / `deleteReusableFrame` / `updateReusableFrameName` / `selectReusableFrame` (legacy `useLayoutsStore` wrapping, P3 이후 직접 canonical mutation 으로 전환)
   - `apps/builder/src/utils/featureFlags.ts` — `isFramesTabCanonical()` + `framesTabCanonical` 필드 추가 (default `false`, dual-mode 운영용)
   - vitest 7/7 PASS / type-check 0
   - **scope 보호**: FramesTab.tsx 미수정 — 기존 동작 0 변화. PR-A 는 baseline 확장만
-- **잔여 Phase 2 sub-PR**: PR-B (FramesTab wrapper consumer 전환) / PR-C (read path canonical 전환 + selector cache 함정 회피) / PR-D (FrameList/FrameDetails/SlotList 분리) / PR-E (PageLayoutSelector + dev migration trigger + dual-mode flag 활성화)
+- **2026-04-27 (세션 37 후속)**: **PR-B: FramesTab consumer → frameActions 위임** (functional 동등)
+  - `FramesTab.tsx` `handleAddFrame` / `handleDeleteFrame` / `handleSelectFrame` → `createReusableFrame` / `deleteReusableFrame` / `selectReusableFrame` 호출로 전환
+  - 핸들러 시그니처 단순화: `(frame: Layout)` → `(frameId: string)` — `frame.id` 만 사용하던 내부 정합화
+  - 제거: `Layout` 타입 import / `setCurrentLayoutInStore` / `createLayout` / `deleteLayout` 직접 destructure (frameActions wrapper 경유)
+  - 유지: `useLayoutsStore.layouts[]` read (PR-C 에서 canonical 전환 예정) / `fetchLayouts` mount effect
+  - type-check 0 / FramesTab 자체 vitest 부재 → PR-A frameActions 7/7 vitest 로 wrapper 행위 검증 (functional 동등 보장)
+- **잔여 Phase 2 sub-PR**: PR-C (read path canonical 전환 + selector cache 함정 회피) / PR-D (FrameList/FrameDetails/SlotList 분리) / PR-E (PageLayoutSelector + dev migration trigger + dual-mode flag 활성화)
 
 ## Context
 

--- a/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
+++ b/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
@@ -440,14 +440,14 @@ const handleDevMigrate = useCallback(async () => {
 
 총 12h 배분. **2026-04-27 세션 37 진입 시 5-PR 보수 분할 채택** — selectCanonicalDocument 매 render 호출 비용 + zustand selector cache 함정 (memory: `feedback-zustand-selector-cache.md`) 회피용:
 
-| Sub-PR | 내용                                                                                             | Step 매핑        | 상태                      |
-| ------ | ------------------------------------------------------------------------------------------------ | ---------------- | ------------------------- |
-| **A**  | `frameActions.ts` skeleton (legacy wrapper) + `isFramesTabCanonical()` flag 추가 (default false) | P2-a 부분 + P2-d | ✅ 2026-04-27 (커밋 예정) |
-| **B**  | `FramesTab.handleAddFrame/handleDeleteFrame` → `frameActions` 위임 (functional 동등)             | P2-a 잔여        | 후속 세션                 |
-| **C**  | read path canonical 전환 — `selectCanonicalDocument` + `useMemo`/`getState` 패턴                 | P2-a 잔여        | 후속 세션                 |
-| **D**  | `FrameList` / `FrameDetails` / `SlotList` 컴포넌트 분리                                          | P2-b             | 후속 세션                 |
-| **E**  | `PageLayoutSelector` 재작성 + `usePresetApply` canonical mutation + dev migration trigger        | P2-c + P2-e      | 후속 세션                 |
-| **G**  | parallel-verify 25/25 + 1주 dual-mode + cutover                                                  | P2-f + P2-g      | 후속 세션                 |
+| Sub-PR | 내용                                                                                                   | Step 매핑        | 상태                                 |
+| ------ | ------------------------------------------------------------------------------------------------------ | ---------------- | ------------------------------------ |
+| **A**  | `frameActions.ts` skeleton (legacy wrapper) + `isFramesTabCanonical()` flag 추가 (default false)       | P2-a 부분 + P2-d | ✅ 2026-04-27 main land (`e9e388ca`) |
+| **B**  | `FramesTab.handleAddFrame/handleDeleteFrame/handleSelectFrame` → `frameActions` 위임 (functional 동등) | P2-a 잔여        | ✅ 2026-04-27 (PR pending)           |
+| **C**  | read path canonical 전환 — `selectCanonicalDocument` + `useMemo`/`getState` 패턴                       | P2-a 잔여        | 후속 세션                            |
+| **D**  | `FrameList` / `FrameDetails` / `SlotList` 컴포넌트 분리                                                | P2-b             | 후속 세션                            |
+| **E**  | `PageLayoutSelector` 재작성 + `usePresetApply` canonical mutation + dev migration trigger              | P2-c + P2-e      | 후속 세션                            |
+| **G**  | parallel-verify 25/25 + 1주 dual-mode + cutover                                                        | P2-f + P2-g      | 후속 세션                            |
 
 | Step       | 내용                                                                                                                      | 시간 | RED/GREEN 사이클                                                                                     |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------- | :--: | ---------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
- handleAddFrame/handleDeleteFrame/handleSelectFrame → frameActions wrapper 호출
- 핸들러 시그니처 단순화: (frame: Layout) → (frameId: string)
- 제거: Layout 타입 import + useLayoutsStore의 createLayout/deleteLayout/setCurrentLayout 직접 destructure
- 유지: useLayoutsStore.layouts[] read (PR-C에서 canonical 전환 예정)

Why: PR-A frameActions wrapper의 첫 consumer 실증. legacy bridge 호출을 wrapper 내부로 격리 → P3 cascade 재작성 시 단일 진입점만 변경.

검증: type-check 0 / frameActions vitest 7/7 PASS (PR-A에서 wrapper 행위 보장)