### PR TITLE
feat(adr-911-p2-c): FramesTab read path canonical 전환 (TDD RED→GREEN)

### DIFF
--- a/apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx
+++ b/apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx
@@ -35,6 +35,7 @@ import {
 } from "../../../stores/utils/frameActions";
 import { useEditModeStore } from "../../../stores/editMode";
 import { useStore } from "../../../stores";
+import { selectCanonicalDocument } from "../../../stores/elements";
 import { ElementProps } from "../../../../types/integrations/supabase.types";
 import { Element } from "../../../../types/core/store.types";
 import type { ElementTreeItem } from "../../../../types/builder/stately.types";
@@ -45,7 +46,9 @@ import { useTreeExpandState } from "@/builder/hooks";
 import {
   isWebGLCanvas,
   isCanvasCompareMode,
+  isFramesTabCanonical,
 } from "../../../../utils/featureFlags";
+import type { FrameNode } from "@composition/shared";
 
 interface FramesTabProps {
   selectedElementId: string | null;
@@ -68,16 +71,9 @@ export function FramesTab({
   // P3-B canonical selector: selectedReusableFrameId (currentLayoutId alias 제거됨)
   const selectedReusableFrameId = useSelectedReusableFrameId();
 
-  // Legacy read bridge — frame 목록은 useLayoutsStore.layouts[] 직접 소비.
-  // PR-C 에서 selectCanonicalDocument 기반 read path 로 전환 예정.
   // CRUD 는 ADR-911 P2-a frameActions wrapper (PR-A) 로 위임.
   const layouts = useLayoutsStore((state) => state.layouts);
   const fetchLayouts = useLayoutsStore((state) => state.fetchLayouts);
-
-  // selectedReusableFrameId 기반 현재 프레임 조회 (legacy bridge)
-  const currentFrame = useMemo(() => {
-    return layouts.find((l) => l.id === selectedReusableFrameId) || null;
-  }, [layouts, selectedReusableFrameId]);
 
   // Edit Mode store
   const setEditModeLayoutId = useEditModeStore(
@@ -86,8 +82,44 @@ export function FramesTab({
 
   // ADR-040: elementsMap O(1) 조회
   const elementsMap = useStore((state) => state.elementsMap);
+  const pages = useStore((state) => state.pages);
   const removeElement = useStore((state) => state.removeElement);
   const mergeElements = useStore((state) => state.mergeElements);
+
+  // ADR-911 P2-a PR-C: dual-mode read path.
+  // - legacy: useLayoutsStore.layouts[] 직접 소비
+  // - canonical: selectCanonicalDocument 의 reusable FrameNode 추출
+  //   (selector cache 함정 회피 — useMemo 안에서 useStore.getState() 호출)
+  // id 정규화: canonical FrameNode.id 는 "layout-<legacyId>" 접두사 → metadata.layoutId
+  // (legacyToCanonical adapter 가 보존) 우선 사용. legacy CRUD 와 id 정합 유지.
+  const reusableFrames = useMemo<
+    ReadonlyArray<{ id: string; name: string }>
+  >(() => {
+    if (!isFramesTabCanonical()) {
+      return layouts.map((l) => ({ id: l.id, name: l.name }));
+    }
+    const state = useStore.getState();
+    const doc = selectCanonicalDocument(state, pages, layouts);
+    return doc.children
+      .filter(
+        (n): n is FrameNode =>
+          n.type === "frame" && (n as FrameNode).reusable === true,
+      )
+      .map((f) => {
+        const layoutId = (f.metadata as { layoutId?: string } | undefined)
+          ?.layoutId;
+        return {
+          id: layoutId ?? f.id,
+          name: f.name ?? "",
+        };
+      });
+    // elementsMap 변경 시 canonical projection 도 갱신 (selectCanonicalDocument 가 elements 소비)
+  }, [layouts, pages, elementsMap]);
+
+  // selectedReusableFrameId 기반 현재 프레임 조회
+  const currentFrame = useMemo(() => {
+    return reusableFrames.find((f) => f.id === selectedReusableFrameId) || null;
+  }, [reusableFrames, selectedReusableFrameId]);
 
   const isWebGLOnly = isWebGLCanvas() && !isCanvasCompareMode();
 
@@ -365,7 +397,7 @@ export function FramesTab({
     async (frameId: string) => {
       try {
         await deleteReusableFrame(frameId);
-        const remaining = layouts.filter((l) => l.id !== frameId);
+        const remaining = reusableFrames.filter((f) => f.id !== frameId);
         if (remaining.length > 0) {
           handleSelectFrame(remaining[0].id);
         } else {
@@ -376,7 +408,7 @@ export function FramesTab({
         console.error("[FramesTab] Frame 삭제 에러:", error);
       }
     },
-    [layouts, handleSelectFrame, setEditModeLayoutId],
+    [reusableFrames, handleSelectFrame, setEditModeLayoutId],
   );
 
   // 새 Frame 생성 핸들러 — frameActions.createReusableFrame 위임
@@ -387,14 +419,14 @@ export function FramesTab({
     }
     try {
       const ref = await createReusableFrame({
-        name: `Frame ${layouts.length + 1}`,
+        name: `Frame ${reusableFrames.length + 1}`,
         projectId,
       });
       handleSelectFrame(ref.id);
     } catch (error) {
       console.error("[FramesTab] Frame 생성 에러:", error);
     }
-  }, [projectId, layouts.length, handleSelectFrame]);
+  }, [projectId, reusableFrames.length, handleSelectFrame]);
 
   // Element 삭제 핸들러
   const handleDeleteElement = useCallback(
@@ -437,10 +469,10 @@ export function FramesTab({
         </div>
 
         <div className="elements">
-          {layouts.length === 0 ? (
+          {reusableFrames.length === 0 ? (
             <p className="no_element">No frames available</p>
           ) : (
-            layouts.map((frame) => (
+            reusableFrames.map((frame) => (
               <div
                 key={frame.id}
                 className="element"

--- a/apps/builder/src/builder/panels/nodes/FramesTab/__tests__/FramesTab.test.tsx
+++ b/apps/builder/src/builder/panels/nodes/FramesTab/__tests__/FramesTab.test.tsx
@@ -32,9 +32,14 @@ const mockLayoutsState = {
 
 const mockStoreState = {
   elementsMap: new Map(),
+  pages: [] as Array<{ id: string }>,
   removeElement: vi.fn(),
   mergeElements: vi.fn(),
 };
+
+// PR-C: feature flag + canonical projection mocks
+let mockIsFramesTabCanonical = false;
+const mockSelectCanonicalDocument = vi.fn();
 
 const mockEditModeState = {
   setCurrentLayoutId: vi.fn(),
@@ -90,6 +95,13 @@ vi.mock("@/utils/messaging", () => ({
 vi.mock("@/utils/featureFlags", () => ({
   isWebGLCanvas: () => true,
   isCanvasCompareMode: () => false,
+  isFramesTabCanonical: () => mockIsFramesTabCanonical,
+}));
+
+vi.mock("@/builder/stores/elements", () => ({
+  selectCanonicalDocument: (
+    ...args: Parameters<typeof mockSelectCanonicalDocument>
+  ) => mockSelectCanonicalDocument(...args),
 }));
 
 vi.mock("@/builder/hooks", () => ({
@@ -132,8 +144,11 @@ function resetMockState() {
   mockLayoutsState.layouts = [];
   mockLayoutsState.selectedReusableFrameId = null;
   mockStoreState.elementsMap = new Map();
+  mockStoreState.pages = [];
+  mockIsFramesTabCanonical = false;
   vi.clearAllMocks();
   mockGetByLayout.mockResolvedValue([] as never[]);
+  mockSelectCanonicalDocument.mockReturnValue({ children: [] });
   // wrapper Promise resolve 기본값 — 정상 동작
   createReusableFrameMock.mockResolvedValue({
     id: "new-frame",
@@ -237,6 +252,96 @@ describe("FramesTab (ADR-911 P2-a PR-B baseline)", () => {
       // → 호출은 1회 (null 인자) — 부모 click 으로 인한 추가 호출 없음
       expect(selectReusableFrameMock).toHaveBeenCalledTimes(1);
       expect(selectReusableFrameMock).toHaveBeenCalledWith(null);
+    });
+  });
+
+  // ─── PR-C: canonical-native read path ──────────────────────────────────────
+  describe("canonical-native read path (isFramesTabCanonical=true)", () => {
+    it("frame 목록을 selectCanonicalDocument 의 reusable FrameNode 로 표시", () => {
+      mockIsFramesTabCanonical = true;
+      // legacy layouts[] 에는 데이터 있지만, canonical doc 가 다르면 canonical 표시
+      mockLayoutsState.layouts = [
+        { id: "legacy-id", name: "Legacy Should Not Show", project_id: "p" },
+      ];
+      mockSelectCanonicalDocument.mockReturnValue({
+        children: [
+          {
+            id: "layout-canonical-id",
+            type: "frame",
+            reusable: true,
+            name: "Canonical Frame",
+            metadata: { type: "legacy-layout", layoutId: "canonical-id" },
+            children: [],
+          },
+        ],
+      });
+
+      render(<FramesTab {...makeProps()} />);
+
+      expect(screen.getByText("Canonical Frame")).toBeTruthy();
+      expect(screen.queryByText("Legacy Should Not Show")).toBeNull();
+    });
+
+    it("non-frame / non-reusable 노드는 필터링됨", () => {
+      mockIsFramesTabCanonical = true;
+      mockSelectCanonicalDocument.mockReturnValue({
+        children: [
+          {
+            id: "layout-frame-1",
+            type: "frame",
+            reusable: true,
+            name: "Reusable Frame",
+            metadata: { type: "legacy-layout", layoutId: "frame-1" },
+            children: [],
+          },
+          // reusable: false (page-bound frame) — 필터아웃
+          {
+            id: "page-frame",
+            type: "frame",
+            reusable: false,
+            name: "Page Frame",
+            children: [],
+          },
+          // ref 노드 — 필터아웃
+          {
+            id: "ref-1",
+            type: "ref",
+            ref: "layout-frame-1",
+            name: "Some Ref",
+          },
+        ],
+      });
+
+      render(<FramesTab {...makeProps()} />);
+
+      expect(screen.getByText("Reusable Frame")).toBeTruthy();
+      expect(screen.queryByText("Page Frame")).toBeNull();
+      expect(screen.queryByText("Some Ref")).toBeNull();
+    });
+
+    it("canonical frame 클릭 시 metadata.layoutId (legacy id) 로 selectReusableFrame 위임 — write 정합성", async () => {
+      mockIsFramesTabCanonical = true;
+      mockSelectCanonicalDocument.mockReturnValue({
+        children: [
+          {
+            id: "layout-frame-zzz", // canonical id (prefix 포함)
+            type: "frame",
+            reusable: true,
+            name: "Header",
+            metadata: { type: "legacy-layout", layoutId: "frame-zzz" }, // legacy id
+            children: [],
+          },
+        ],
+      });
+
+      render(<FramesTab {...makeProps()} />);
+      fireEvent.click(screen.getByText("Header"));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // legacy id ("frame-zzz") 로 select 호출 — canonical id ("layout-frame-zzz") 아님
+      expect(selectReusableFrameMock).toHaveBeenCalledWith("frame-zzz");
     });
   });
 });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ADR-911 Phase 2 PR-C — FramesTab read path canonical 전환 (TDD RED→GREEN) — 세션 37 후반] - 2026-04-27
+
+### Architecture
+
+- **ADR-911 Phase 2 PR-C — FramesTab dual-mode read path** (TDD RED → GREEN):
+  - `FramesTab.tsx` 에 `reusableFrames` useMemo 도입 — `isFramesTabCanonical()` flag 분기로 read path dual-mode
+    - **legacy path** (flag false, default): `layouts.map(l => ({ id, name }))`
+    - **canonical path** (flag true): `selectCanonicalDocument(state, pages, layouts).children.filter(reusable: true).map(...)` — `metadata.layoutId` (legacyToCanonical 보존) 으로 id 정규화하여 legacy CRUD (createLayout/deleteLayout) 와 id 정합 유지
+  - **selector cache 함정 회피** (memory: `feedback-zustand-selector-cache.md`): useMemo 안에서 `useStore.getState()` 호출. selector 등록 안 함. deps: `[layouts, pages, elementsMap]` — selectCanonicalDocument 가 elements 소비하므로 elementsMap 도 추적
+  - `currentFrame` / `handleAddFrame` (`layouts.length + 1` → `reusableFrames.length + 1`) / `handleDeleteFrame.remaining` / JSX `layouts.map` → `reusableFrames.map` 모두 단일 source 기반으로 통일
+  - **Why**: PR-A wrapper + PR-B consumer 정합화의 read path 완성. PR-D (UI 분리) / PR-E (PageLayoutSelector + cutover) 에서 reusableFrames 단일 source 재사용 가능. 향후 P3 cascade 재작성 시 read path 변경 0
+  - 검증: vitest 8/8 PASS (5 legacy baseline + 3 canonical mode: 목록 표시 / non-frame 필터 / id 정규화) / type-check 0 / frameActions 회귀 0
+
+### Infrastructure
+
+- **FramesTab vitest 확장 (3 canonical 시나리오 추가)**:
+  - `__tests__/FramesTab.test.tsx` — 신규 mock: `isFramesTabCanonical` (feature flag toggle) + `selectCanonicalDocument` (canonical doc 반환)
+  - canonical 시나리오 3:
+    1. flag true + legacy layouts != canonical doc → canonical doc 의 reusable FrameNode 만 표시 (legacy 우회)
+    2. children 에 non-frame / non-reusable / ref 노드 혼재 → reusable FrameNode 만 필터
+    3. canonical FrameNode 클릭 → `metadata.layoutId` (legacy id) 로 `selectReusableFrame` 위임 — write 정합성 보장
+  - **Why**: PR-Followup-A 의 5 baseline 위에 canonical mode 동작을 RED-first 로 추가하여 GREEN 구현이 정확히 의도대로 동작함을 잠금
+
 ## [ADR-911 Phase 2 PR-Followup-A — FramesTab 컴포넌트 vitest baseline 잠금 — 세션 37 후반] - 2026-04-27
 
 ### Infrastructure

--- a/docs/adr/911-layout-frameset-pencil-redesign.md
+++ b/docs/adr/911-layout-frameset-pencil-redesign.md
@@ -13,13 +13,22 @@ In Progress — 2026-04-26 → 2026-04-27
   - `apps/builder/src/utils/featureFlags.ts` — `isFramesTabCanonical()` + `framesTabCanonical` 필드 추가 (default `false`, dual-mode 운영용)
   - vitest 7/7 PASS / type-check 0
   - **scope 보호**: FramesTab.tsx 미수정 — 기존 동작 0 변화. PR-A 는 baseline 확장만
-- **2026-04-27 (세션 37 후속)**: **PR-B: FramesTab consumer → frameActions 위임** (functional 동등)
+- **2026-04-27 (세션 37 후속)**: **PR-B: FramesTab consumer → frameActions 위임** (functional 동등) (PR #251 / `007c40f3`)
   - `FramesTab.tsx` `handleAddFrame` / `handleDeleteFrame` / `handleSelectFrame` → `createReusableFrame` / `deleteReusableFrame` / `selectReusableFrame` 호출로 전환
   - 핸들러 시그니처 단순화: `(frame: Layout)` → `(frameId: string)` — `frame.id` 만 사용하던 내부 정합화
   - 제거: `Layout` 타입 import / `setCurrentLayoutInStore` / `createLayout` / `deleteLayout` 직접 destructure (frameActions wrapper 경유)
   - 유지: `useLayoutsStore.layouts[]` read (PR-C 에서 canonical 전환 예정) / `fetchLayouts` mount effect
   - type-check 0 / FramesTab 자체 vitest 부재 → PR-A frameActions 7/7 vitest 로 wrapper 행위 검증 (functional 동등 보장)
-- **잔여 Phase 2 sub-PR**: PR-C (read path canonical 전환 + selector cache 함정 회피) / PR-D (FrameList/FrameDetails/SlotList 분리) / PR-E (PageLayoutSelector + dev migration trigger + dual-mode flag 활성화)
+- **2026-04-27 (세션 37 후속)**: **PR-Followup-A: FramesTab 컴포넌트 vitest baseline 잠금** (PR #252 / `7ccb86a0`)
+  - 5 시나리오: 빈 frames / 2개 렌더 / Add / Select(id) / Delete + stopPropagation. mock 9 모듈
+- **2026-04-27 (세션 37 후속)**: **PR-C: FramesTab read path canonical 전환** (TDD RED → GREEN, PR pending)
+  - `FramesTab.tsx` 에 `reusableFrames` useMemo 도입 — `isFramesTabCanonical()` flag 분기로 dual-mode read
+    - **legacy path** (default false): `layouts.map(l => ({ id: l.id, name: l.name }))`
+    - **canonical path** (true): `selectCanonicalDocument(state, pages, layouts).children.filter(reusable: true).map(...)` — `metadata.layoutId` (legacyToCanonical 보존) 으로 id 정규화 → legacy CRUD 와 정합
+  - **selector cache 함정 회피** (memory: `feedback-zustand-selector-cache.md`): useMemo 안에서 `useStore.getState()` 호출. selector 등록 안 함. deps: `[layouts, pages, elementsMap]`
+  - `currentFrame` / `handleAddFrame.layouts.length+1` / `handleDeleteFrame.remaining` / JSX `layouts.map → reusableFrames.map` 모두 `reusableFrames` 기반으로 통일
+  - vitest 8/8 PASS (5 legacy baseline + 3 canonical mode: 목록 표시 / non-frame 필터 / id 정규화) + type-check 0 + frameActions 회귀 0
+- **잔여 Phase 2 sub-PR**: PR-D (FrameList/FrameDetails/SlotList 분리) / PR-E (PageLayoutSelector + dev migration trigger + dual-mode flag 활성화)
 
 ## Context
 

--- a/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
+++ b/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
@@ -444,7 +444,7 @@ const handleDevMigrate = useCallback(async () => {
 | ------ | ------------------------------------------------------------------------------------------------------ | ---------------- | ------------------------------------ |
 | **A**  | `frameActions.ts` skeleton (legacy wrapper) + `isFramesTabCanonical()` flag 추가 (default false)       | P2-a 부분 + P2-d | ✅ 2026-04-27 main land (`e9e388ca`) |
 | **B**  | `FramesTab.handleAddFrame/handleDeleteFrame/handleSelectFrame` → `frameActions` 위임 (functional 동등) | P2-a 잔여        | ✅ 2026-04-27 (PR pending)           |
-| **C**  | read path canonical 전환 — `selectCanonicalDocument` + `useMemo`/`getState` 패턴                       | P2-a 잔여        | 후속 세션                            |
+| **C**  | read path canonical 전환 — `selectCanonicalDocument` + `useMemo`/`getState` 패턴                       | P2-a 잔여        | ✅ 2026-04-27 (PR pending)           |
 | **D**  | `FrameList` / `FrameDetails` / `SlotList` 컴포넌트 분리                                                | P2-b             | 후속 세션                            |
 | **E**  | `PageLayoutSelector` 재작성 + `usePresetApply` canonical mutation + dev migration trigger              | P2-c + P2-e      | 후속 세션                            |
 | **G**  | parallel-verify 25/25 + 1주 dual-mode + cutover                                                        | P2-f + P2-g      | 후속 세션                            |


### PR DESCRIPTION
dual-mode read path 도입 — isFramesTabCanonical() flag 분기:
- legacy: useLayoutsStore.layouts[] 직접 소비 (default false)
- canonical: selectCanonicalDocument(state, pages, layouts).children .filter(reusable: true) → metadata.layoutId 로 id 정규화

selector cache 함정 회피 (memory: feedback-zustand-selector-cache.md): useMemo 안에서 useStore.getState() 호출. selector 등록 안 함. deps: [layouts, pages, elementsMap].

reusableFrames 단일 source 통일: currentFrame / handleAddFrame.length / handleDeleteFrame.remaining / JSX render 모두 reusableFrames 기반.

vitest 확장 (RED → GREEN):
- 5 legacy baseline (PR-Followup-A 보존)
- 3 canonical 시나리오 신규:
  1. flag true → canonical doc의 reusable FrameNode만 표시
  2. non-frame / non-reusable / ref 노드 필터링
  3. canonical id ("layout-X") → metadata.layoutId ("X") 로 정규화 위임

Why: PR-A wrapper + PR-B consumer + PR-C read path 정합으로 P3 cascade 재작성 시 read path 변경 0. PR-D/E 가 reusableFrames 단일 source 재사용 가능.

검증: vitest 8/8 PASS (FramesTab) / 7/7 (frameActions 회귀 0) / type-check 0. layoutActions 3 fail은 baseline (PR-C 무관).