### PR TITLE
refactor(adr-911-p2-d): FrameList 프레젠테이션 컴포넌트 분리 (functional 동등)

### DIFF
--- a/apps/builder/src/builder/panels/nodes/FramesTab/FrameList.tsx
+++ b/apps/builder/src/builder/panels/nodes/FramesTab/FrameList.tsx
@@ -1,0 +1,107 @@
+/**
+ * FrameList — reusable frame 목록 컴포넌트.
+ *
+ * ADR-911 Phase 2 PR-D: FramesTab.tsx 의 `sidebar_layouts` 영역 (frame 목록 + Add 버튼) 추출.
+ *
+ * 본 컴포넌트는 프레젠테이션 전용 — 데이터 source (legacy/canonical) 결정과
+ * frame CRUD 로직은 부모 (FramesTab) 책임. props 로 데이터/핸들러 주입받아
+ * UI 만 렌더한다.
+ *
+ * functional 동등 — 추출 전후 동작 차이 없음 (PR-Followup-A 의 5 baseline 시나리오 + PR-C 의 8/8 시나리오 회귀 0).
+ */
+
+import { CirclePlus, Box, Trash } from "lucide-react";
+import { iconProps } from "../../../../utils/ui/uiConstants";
+
+export interface FrameListItem {
+  id: string;
+  name: string;
+}
+
+export interface FrameListProps {
+  /** 표시할 frame 목록 (legacy 또는 canonical projection 결과) */
+  frames: ReadonlyArray<FrameListItem>;
+  /** 현재 선택된 frame id (active 표시용) */
+  selectedFrameId: string | null;
+  /** Frame 항목 클릭 핸들러 */
+  onSelect: (frameId: string) => void;
+  /** Delete 버튼 클릭 핸들러 (stopPropagation 은 컴포넌트 내부에서 처리) */
+  onDelete: (frameId: string) => void;
+  /** Add Frame 버튼 클릭 핸들러 */
+  onAdd: () => void;
+}
+
+export function FrameList({
+  frames,
+  selectedFrameId,
+  onSelect,
+  onDelete,
+  onAdd,
+}: FrameListProps) {
+  return (
+    <div className="sidebar_layouts">
+      <div className="panel-header">
+        <h3 className="panel-title">Frames</h3>
+        <div className="header-actions">
+          <button className="iconButton" aria-label="Add Frame" onClick={onAdd}>
+            <CirclePlus
+              color={iconProps.color}
+              strokeWidth={iconProps.strokeWidth}
+              size={iconProps.size}
+            />
+          </button>
+        </div>
+      </div>
+
+      <div className="elements">
+        {frames.length === 0 ? (
+          <p className="no_element">No frames available</p>
+        ) : (
+          frames.map((frame) => (
+            <div
+              key={frame.id}
+              className="element"
+              onClick={() => onSelect(frame.id)}
+            >
+              <div
+                className={`elementItem ${
+                  selectedFrameId === frame.id ? "active" : ""
+                }`}
+              >
+                <div
+                  className="elementItemIndent"
+                  style={{ width: "0px" }}
+                ></div>
+                <div className="elementItemIcon">
+                  <Box
+                    color={iconProps.color}
+                    strokeWidth={iconProps.strokeWidth}
+                    size={iconProps.size}
+                    style={{ padding: "2px" }}
+                  />
+                </div>
+                <div className="elementItemLabel">{frame.name}</div>
+                <div className="elementItemActions">
+                  <button
+                    className="iconButton"
+                    aria-label={`Delete ${frame.name}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDelete(frame.id);
+                    }}
+                  >
+                    <Trash
+                      color={iconProps.color}
+                      strokeWidth={iconProps.strokeWidth}
+                      size={iconProps.size}
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx
+++ b/apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx
@@ -15,15 +15,9 @@
 
 import React, { useCallback, useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
-import {
-  CirclePlus,
-  Minimize,
-  ChevronRight,
-  Box,
-  Trash,
-  Settings2,
-} from "lucide-react";
+import { Minimize, ChevronRight, Box, Trash, Settings2 } from "lucide-react";
 import { iconProps } from "../../../../utils/ui/uiConstants";
+import { FrameList } from "./FrameList";
 import {
   useLayoutsStore,
   useSelectedReusableFrameId,
@@ -449,75 +443,14 @@ export function FramesTab({
       id="tabpanel-frames"
       aria-label="Frames"
     >
-      {/* Frames List */}
-      <div className="sidebar_layouts">
-        <div className="panel-header">
-          <h3 className="panel-title">Frames</h3>
-          <div className="header-actions">
-            <button
-              className="iconButton"
-              aria-label="Add Frame"
-              onClick={handleAddFrame}
-            >
-              <CirclePlus
-                color={iconProps.color}
-                strokeWidth={iconProps.strokeWidth}
-                size={iconProps.size}
-              />
-            </button>
-          </div>
-        </div>
-
-        <div className="elements">
-          {reusableFrames.length === 0 ? (
-            <p className="no_element">No frames available</p>
-          ) : (
-            reusableFrames.map((frame) => (
-              <div
-                key={frame.id}
-                className="element"
-                onClick={() => handleSelectFrame(frame.id)}
-              >
-                <div
-                  className={`elementItem ${
-                    currentFrame?.id === frame.id ? "active" : ""
-                  }`}
-                >
-                  <div
-                    className="elementItemIndent"
-                    style={{ width: "0px" }}
-                  ></div>
-                  <div className="elementItemIcon">
-                    <Box
-                      color={iconProps.color}
-                      strokeWidth={iconProps.strokeWidth}
-                      size={iconProps.size}
-                      style={{ padding: "2px" }}
-                    />
-                  </div>
-                  <div className="elementItemLabel">{frame.name}</div>
-                  <div className="elementItemActions">
-                    <button
-                      className="iconButton"
-                      aria-label={`Delete ${frame.name}`}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleDeleteFrame(frame.id);
-                      }}
-                    >
-                      <Trash
-                        color={iconProps.color}
-                        strokeWidth={iconProps.strokeWidth}
-                        size={iconProps.size}
-                      />
-                    </button>
-                  </div>
-                </div>
-              </div>
-            ))
-          )}
-        </div>
-      </div>
+      {/* Frames List — ADR-911 P2 PR-D 추출 */}
+      <FrameList
+        frames={reusableFrames}
+        selectedFrameId={currentFrame?.id ?? null}
+        onSelect={handleSelectFrame}
+        onDelete={handleDeleteFrame}
+        onAdd={handleAddFrame}
+      />
 
       {/* Frame Element Tree */}
       <div className="sidebar_elements">

--- a/apps/builder/src/builder/panels/nodes/FramesTab/__tests__/FrameList.test.tsx
+++ b/apps/builder/src/builder/panels/nodes/FramesTab/__tests__/FrameList.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+/**
+ * ADR-911 Phase 2 PR-D — FrameList 컴포넌트 단위 테스트.
+ *
+ * 본 테스트는 FrameList 가 프레젠테이션 전용임을 검증한다 — 데이터 source 와
+ * 핸들러 구현은 외부 책임이고, FrameList 는 props 만으로 결정적 UI 를 렌더한다.
+ *
+ * 시나리오 5개:
+ *  1. 빈 frames → "No frames available"
+ *  2. 2개 frames 렌더 → 이름 모두 표시
+ *  3. Add 버튼 클릭 → onAdd 호출 (frame id 인자 없음)
+ *  4. Frame 항목 클릭 → onSelect(frame.id) 호출
+ *  5. Delete 버튼 클릭 → onDelete(frame.id) 호출 + onSelect 미호출 (stopPropagation)
+ *
+ * + selectedFrameId 매칭 시 active 클래스 표시 확인.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, screen, cleanup } from "@testing-library/react";
+
+import { FrameList } from "../FrameList";
+
+function makeProps(
+  override: Partial<React.ComponentProps<typeof FrameList>> = {},
+): React.ComponentProps<typeof FrameList> {
+  return {
+    frames: [],
+    selectedFrameId: null,
+    onSelect: vi.fn(),
+    onDelete: vi.fn(),
+    onAdd: vi.fn(),
+    ...override,
+  };
+}
+
+describe("FrameList (ADR-911 P2 PR-D)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("rendering", () => {
+    it("frames 가 비어있으면 'No frames available' 표시", () => {
+      render(<FrameList {...makeProps({ frames: [] })} />);
+      expect(screen.getByText("No frames available")).toBeTruthy();
+    });
+
+    it("frames 2개를 받으면 각 name 을 모두 표시한다", () => {
+      render(
+        <FrameList
+          {...makeProps({
+            frames: [
+              { id: "f-1", name: "Header Frame" },
+              { id: "f-2", name: "Footer Frame" },
+            ],
+          })}
+        />,
+      );
+      expect(screen.getByText("Header Frame")).toBeTruthy();
+      expect(screen.getByText("Footer Frame")).toBeTruthy();
+    });
+
+    it("selectedFrameId 와 매칭되는 frame 만 active 클래스 표시", () => {
+      const { container } = render(
+        <FrameList
+          {...makeProps({
+            frames: [
+              { id: "f-1", name: "Selected" },
+              { id: "f-2", name: "Other" },
+            ],
+            selectedFrameId: "f-1",
+          })}
+        />,
+      );
+
+      const items = container.querySelectorAll(".elementItem");
+      expect(items[0].className).toContain("active");
+      expect(items[1].className).not.toContain("active");
+    });
+  });
+
+  describe("interactions", () => {
+    it("Add 버튼 클릭 시 onAdd 호출", () => {
+      const onAdd = vi.fn();
+      render(<FrameList {...makeProps({ onAdd })} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Add Frame" }));
+
+      // React onClick 은 SyntheticEvent 를 인자로 전달 — 호출 횟수만 검증
+      expect(onAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it("Frame 항목 클릭 시 onSelect(frameId) 호출", () => {
+      const onSelect = vi.fn();
+      render(
+        <FrameList
+          {...makeProps({
+            frames: [{ id: "frame-abc", name: "Header" }],
+            onSelect,
+          })}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Header"));
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+      expect(onSelect).toHaveBeenCalledWith("frame-abc");
+    });
+
+    it("Delete 버튼 클릭 시 onDelete(frameId) + stopPropagation (onSelect 미호출)", () => {
+      const onSelect = vi.fn();
+      const onDelete = vi.fn();
+      render(
+        <FrameList
+          {...makeProps({
+            frames: [{ id: "frame-xyz", name: "Doomed" }],
+            onSelect,
+            onDelete,
+          })}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Delete Doomed" }));
+
+      expect(onDelete).toHaveBeenCalledTimes(1);
+      expect(onDelete).toHaveBeenCalledWith("frame-xyz");
+      // stopPropagation: 부모 onClick (onSelect) 미호출
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ADR-911 Phase 2 PR-D — FrameList 컴포넌트 분리 — 세션 37 후반] - 2026-04-27
+
+### Architecture
+
+- **ADR-911 Phase 2 PR-D — FrameList 프레젠테이션 컴포넌트 추출** (functional 동등):
+  - `apps/builder/src/builder/panels/nodes/FramesTab/FrameList.tsx` 신규 (108 lines)
+    - props: `frames` / `selectedFrameId` / `onSelect` / `onDelete` / `onAdd`
+    - 책임: frame 목록 + Add 버튼 + Delete 버튼 (Box icon + name + active 표시) + stopPropagation
+  - `FramesTab.tsx` 의 `sidebar_layouts` JSX 영역 (62 lines) → `<FrameList>` 컴포넌트 호출 (8 lines) 로 교체
+  - 미사용 `CirclePlus` lucide import 제거
+  - **Why**: 데이터 source (legacy/canonical) 결정과 frame CRUD 로직은 부모 (FramesTab) 책임, FrameList 는 props 기반 결정적 UI 만 담당. PR-E (PageLayoutSelector — RefNode.ref 선택 UI) 가 동일 FrameList 컴포넌트 재사용 가능. PR-D2 (FrameElementTree 분리) 진입 시 FramesTab 의 책임이 orchestrator 만 남음
+  - 검증: vitest 14/14 PASS (FrameList 6 + FramesTab 8) / frameActions 7/7 (회귀 0) / type-check 0
+
+### Infrastructure
+
+- **FrameList vitest 신규** (6 시나리오):
+  - `__tests__/FrameList.test.tsx` — 프레젠테이션 단위 테스트 (mock 0 — props 순수 함수)
+  - 시나리오: 빈 frames → "No frames available" / 2개 렌더 → 이름 표시 / `selectedFrameId` 매칭 → active 클래스 / Add 클릭 → onAdd / Frame 클릭 → onSelect(id) / Delete 클릭 → onDelete(id) + onSelect 미호출 (stopPropagation)
+  - **Why**: 컴포넌트 분리 시점에 결정적 UI 계약을 잠금. PR-E 에서 다른 consumer (PageLayoutSelector 등) 가 같은 props 인터페이스로 재사용 시 회귀 즉시 감지
+
 ## [ADR-911 Phase 2 PR-C — FramesTab read path canonical 전환 (TDD RED→GREEN) — 세션 37 후반] - 2026-04-27
 
 ### Architecture

--- a/docs/adr/911-layout-frameset-pencil-redesign.md
+++ b/docs/adr/911-layout-frameset-pencil-redesign.md
@@ -21,14 +21,20 @@ In Progress — 2026-04-26 → 2026-04-27
   - type-check 0 / FramesTab 자체 vitest 부재 → PR-A frameActions 7/7 vitest 로 wrapper 행위 검증 (functional 동등 보장)
 - **2026-04-27 (세션 37 후속)**: **PR-Followup-A: FramesTab 컴포넌트 vitest baseline 잠금** (PR #252 / `7ccb86a0`)
   - 5 시나리오: 빈 frames / 2개 렌더 / Add / Select(id) / Delete + stopPropagation. mock 9 모듈
-- **2026-04-27 (세션 37 후속)**: **PR-C: FramesTab read path canonical 전환** (TDD RED → GREEN, PR pending)
+- **2026-04-27 (세션 37 후속)**: **PR-C: FramesTab read path canonical 전환** (TDD RED → GREEN, PR #253 / `e9be92e4`)
   - `FramesTab.tsx` 에 `reusableFrames` useMemo 도입 — `isFramesTabCanonical()` flag 분기로 dual-mode read
     - **legacy path** (default false): `layouts.map(l => ({ id: l.id, name: l.name }))`
     - **canonical path** (true): `selectCanonicalDocument(state, pages, layouts).children.filter(reusable: true).map(...)` — `metadata.layoutId` (legacyToCanonical 보존) 으로 id 정규화 → legacy CRUD 와 정합
   - **selector cache 함정 회피** (memory: `feedback-zustand-selector-cache.md`): useMemo 안에서 `useStore.getState()` 호출. selector 등록 안 함. deps: `[layouts, pages, elementsMap]`
   - `currentFrame` / `handleAddFrame.layouts.length+1` / `handleDeleteFrame.remaining` / JSX `layouts.map → reusableFrames.map` 모두 `reusableFrames` 기반으로 통일
   - vitest 8/8 PASS (5 legacy baseline + 3 canonical mode: 목록 표시 / non-frame 필터 / id 정규화) + type-check 0 + frameActions 회귀 0
-- **잔여 Phase 2 sub-PR**: PR-D (FrameList/FrameDetails/SlotList 분리) / PR-E (PageLayoutSelector + dev migration trigger + dual-mode flag 활성화)
+- **2026-04-27 (세션 37 후속)**: **PR-D: FrameList 컴포넌트 분리** (functional 동등, PR pending)
+  - `FrameList.tsx` 신규 — frame 목록 + Add/Delete 버튼 (props: `frames` / `selectedFrameId` / `onSelect` / `onDelete` / `onAdd`)
+  - `FramesTab.tsx` 의 `sidebar_layouts` JSX 영역 (62 lines) 을 `<FrameList>` 컴포넌트로 교체. `CirclePlus` import 제거
+  - `__tests__/FrameList.test.tsx` 신규 (6 시나리오: 빈 / 2개 렌더 / active 클래스 / Add / Select / Delete + stopPropagation)
+  - 검증: vitest 14/14 PASS (FrameList 6 + FramesTab 8) / frameActions 7/7 (회귀 0) / type-check 0
+  - **Why**: 프레젠테이션 분리 — 데이터 source (legacy/canonical) 결정과 frame CRUD 로직은 부모 책임, FrameList 는 props 기반 결정적 UI 만 담당. PR-E 진입 시 동일 컴포넌트 재사용 가능
+- **잔여 Phase 2 sub-PR**: PR-D2 (FrameElementTree 분리, optional) / PR-E (PageLayoutSelector + dev migration trigger + dual-mode flag 활성화)
 
 ## Context
 

--- a/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
+++ b/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
@@ -445,7 +445,7 @@ const handleDevMigrate = useCallback(async () => {
 | **A**  | `frameActions.ts` skeleton (legacy wrapper) + `isFramesTabCanonical()` flag 추가 (default false)       | P2-a 부분 + P2-d | ✅ 2026-04-27 main land (`e9e388ca`) |
 | **B**  | `FramesTab.handleAddFrame/handleDeleteFrame/handleSelectFrame` → `frameActions` 위임 (functional 동등) | P2-a 잔여        | ✅ 2026-04-27 (PR pending)           |
 | **C**  | read path canonical 전환 — `selectCanonicalDocument` + `useMemo`/`getState` 패턴                       | P2-a 잔여        | ✅ 2026-04-27 (PR pending)           |
-| **D**  | `FrameList` / `FrameDetails` / `SlotList` 컴포넌트 분리                                                | P2-b             | 후속 세션                            |
+| **D**  | `FrameList` 분리 (FrameDetails / SlotList 는 D2/E 로 deferred)                                         | P2-b             | ✅ 2026-04-27 (PR pending)           |
 | **E**  | `PageLayoutSelector` 재작성 + `usePresetApply` canonical mutation + dev migration trigger              | P2-c + P2-e      | 후속 세션                            |
 | **G**  | parallel-verify 25/25 + 1주 dual-mode + cutover                                                        | P2-f + P2-g      | 후속 세션                            |
 


### PR DESCRIPTION
FrameList.tsx 신규 — frame 목록 + Add/Delete 버튼.
props: frames / selectedFrameId / onSelect / onDelete / onAdd.

FramesTab.tsx 의 sidebar_layouts JSX (62줄) → <FrameList> 호출 (8줄). 미사용 CirclePlus import 제거.

FrameList vitest 6/6 PASS (mock 0):
- 빈 frames → "No frames available"
- 2개 렌더 → 이름 표시
- selectedFrameId 매칭 → active 클래스
- Add 클릭 → onAdd
- Frame 클릭 → onSelect(id)
- Delete 클릭 → onDelete(id) + onSelect 미호출 (stopPropagation)

Why: 데이터 source (legacy/canonical) 결정과 frame CRUD 로직은 부모 (FramesTab) 책임, FrameList 는 props 기반 결정적 UI 만 담당.
PR-E (PageLayoutSelector RefNode.ref 선택 UI) 가 같은 컴포넌트 재사용 가능. PR-D2 (FrameElementTree 분리) 진입 시 FramesTab 은 orchestrator 만 남음.

검증: vitest 14/14 PASS (FrameList 6 + FramesTab 8) / frameActions 7/7 (회귀 0) / type-check 0.