### PR TITLE
refactor(adr-911-p2-d2): FrameElementTree 프레젠테이션 컴포넌트 분리 (functional 동등)

### DIFF
--- a/apps/builder/src/builder/panels/nodes/FramesTab/FrameElementTree.tsx
+++ b/apps/builder/src/builder/panels/nodes/FramesTab/FrameElementTree.tsx
@@ -1,0 +1,201 @@
+/**
+ * FrameElementTree — frame 의 element 트리 렌더 + Layers 헤더 + Collapse All 버튼.
+ *
+ * ADR-911 Phase 2 PR-D2: FramesTab.tsx 의 `sidebar_elements` 영역 (Layers 헤더 +
+ * tree 렌더 + placeholder) 추출.
+ *
+ * 본 컴포넌트는 프레젠테이션 전용 — element 선택 / 삭제 핸들러 구현은 부모 책임.
+ * tree 데이터, expand 상태, 핸들러 모두 props 로 주입받아 결정적 UI 만 렌더.
+ *
+ * functional 동등 — 추출 전후 동작 차이 없음 (FramesTab 8/8 회귀 0).
+ */
+
+import React from "react";
+import { Minimize, ChevronRight, Box, Trash, Settings2 } from "lucide-react";
+import { iconProps } from "../../../../utils/ui/uiConstants";
+import type { ElementProps } from "../../../../types/integrations/supabase.types";
+import type { Element } from "../../../../types/core/store.types";
+import type { ElementTreeItem } from "../../../../types/builder/stately.types";
+
+export interface FrameElementTreeProps {
+  /** 렌더할 element 트리 */
+  tree: ElementTreeItem[];
+  /** 현재 선택된 frame id (없으면 placeholder 표시 + element 의 layout_id 매핑 source) */
+  frameId: string | null;
+  /** 현재 선택된 element id (active 표시용) */
+  selectedElementId: string | null;
+  /** 펼쳐진 element id 집합 */
+  expandedKeys: ReadonlySet<string>;
+  /** 펼침/접힘 토글 */
+  toggleKey: (id: string) => void;
+  /** Collapse All 버튼 핸들러 */
+  onCollapseAll: () => void;
+  /** Element 항목 클릭 핸들러 */
+  onElementClick: (element: Element) => void;
+  /** Element 삭제 버튼 핸들러 */
+  onElementDelete: (element: Element) => Promise<void> | void;
+}
+
+export function FrameElementTree({
+  tree,
+  frameId,
+  selectedElementId,
+  expandedKeys,
+  toggleKey,
+  onCollapseAll,
+  onElementClick,
+  onElementDelete,
+}: FrameElementTreeProps) {
+  const renderTree = (
+    items: ElementTreeItem[],
+    currentDepth: number,
+  ): React.ReactNode => {
+    if (items.length === 0) return null;
+
+    return (
+      <>
+        {items.map((item) => {
+          const hasChildNodes = item.children && item.children.length > 0;
+          const isExpanded = expandedKeys.has(item.id);
+
+          const element: Element = {
+            id: item.id,
+            type: item.type,
+            parent_id: item.parent_id || null,
+            order_num: item.order_num,
+            props: item.props as ElementProps,
+            deleted: item.deleted,
+            layout_id: frameId ?? null,
+            page_id: null,
+            created_at: "",
+            updated_at: "",
+          };
+
+          return (
+            <div
+              key={item.id}
+              data-depth={currentDepth}
+              data-has-children={hasChildNodes}
+              onClick={(e) => {
+                e.stopPropagation();
+                onElementClick(element);
+              }}
+              className="element"
+            >
+              <div
+                className={`elementItem ${
+                  selectedElementId === item.id ? "active" : ""
+                }`}
+              >
+                <div
+                  className="elementItemIndent"
+                  style={{
+                    width: currentDepth > 0 ? `${currentDepth * 8}px` : "0px",
+                  }}
+                ></div>
+                <div
+                  className="elementItemIcon"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (hasChildNodes) {
+                      toggleKey(item.id);
+                    }
+                  }}
+                >
+                  {hasChildNodes ? (
+                    <ChevronRight
+                      color={iconProps.color}
+                      strokeWidth={iconProps.strokeWidth}
+                      size={iconProps.size}
+                      style={{
+                        transform: isExpanded
+                          ? "rotate(90deg)"
+                          : "rotate(0deg)",
+                      }}
+                    />
+                  ) : (
+                    <Box
+                      color={iconProps.color}
+                      strokeWidth={iconProps.strokeWidth}
+                      size={iconProps.size}
+                      style={{ padding: "2px" }}
+                    />
+                  )}
+                </div>
+                <div className="elementItemLabel">
+                  {item.type === "Slot" && item.props
+                    ? `Slot: ${
+                        (item.props as Record<string, unknown>).name ||
+                        "unnamed"
+                      }`
+                    : item.type}
+                </div>
+                <div className="elementItemActions">
+                  {item.type === "body" && (
+                    <button className="iconButton" aria-label="Settings">
+                      <Settings2
+                        color={iconProps.color}
+                        strokeWidth={iconProps.strokeWidth}
+                        size={iconProps.size}
+                      />
+                    </button>
+                  )}
+                  {item.type !== "body" && (
+                    <button
+                      className="iconButton"
+                      aria-label={`Delete ${item.type}`}
+                      onClick={async (e) => {
+                        e.stopPropagation();
+                        await onElementDelete(element);
+                      }}
+                    >
+                      <Trash
+                        color={iconProps.color}
+                        strokeWidth={iconProps.strokeWidth}
+                        size={iconProps.size}
+                      />
+                    </button>
+                  )}
+                </div>
+              </div>
+              {isExpanded &&
+                hasChildNodes &&
+                item.children &&
+                renderTree(item.children, currentDepth + 1)}
+            </div>
+          );
+        })}
+      </>
+    );
+  };
+
+  return (
+    <div className="sidebar_elements">
+      <div className="panel-header">
+        <h3 className="panel-title">Layers</h3>
+        <div className="header-actions">
+          <button
+            className="iconButton"
+            aria-label="Collapse All"
+            onClick={onCollapseAll}
+          >
+            <Minimize
+              color={iconProps.color}
+              strokeWidth={iconProps.strokeWidth}
+              size={iconProps.size}
+            />
+          </button>
+        </div>
+      </div>
+      <div className="elements">
+        {!frameId ? (
+          <p className="no_element">Select a frame to view elements</p>
+        ) : tree.length === 0 ? (
+          <p className="no_element">No elements in this frame</p>
+        ) : (
+          renderTree(tree, 0)
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx
+++ b/apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx
@@ -15,9 +15,8 @@
 
 import React, { useCallback, useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
-import { Minimize, ChevronRight, Box, Trash, Settings2 } from "lucide-react";
-import { iconProps } from "../../../../utils/ui/uiConstants";
 import { FrameList } from "./FrameList";
+import { FrameElementTree } from "./FrameElementTree";
 import {
   useLayoutsStore,
   useSelectedReusableFrameId,
@@ -32,7 +31,6 @@ import { useStore } from "../../../stores";
 import { selectCanonicalDocument } from "../../../stores/elements";
 import { ElementProps } from "../../../../types/integrations/supabase.types";
 import { Element } from "../../../../types/core/store.types";
-import type { ElementTreeItem } from "../../../../types/builder/stately.types";
 import { buildTreeFromElements } from "../../../utils/treeUtils";
 import { MessageService } from "../../../../utils/messaging";
 import { getDB } from "../../../../lib/db";
@@ -227,143 +225,6 @@ export function FramesTab({
     requestAutoSelectAfterUpdate,
   ]);
 
-  // Frame 전용 Element Tree 렌더링
-  const renderFrameTree = useCallback(
-    (
-      tree: ElementTreeItem[],
-      onClick: (item: Element) => void,
-      onDelete: (item: Element) => Promise<void>,
-      depth: number = 0,
-    ): React.ReactNode => {
-      const renderTree = (
-        items: ElementTreeItem[],
-        currentDepth: number,
-      ): React.ReactNode => {
-        if (items.length === 0) return null;
-
-        return (
-          <>
-            {items.map((item) => {
-              const hasChildNodes = item.children && item.children.length > 0;
-              const isExpanded = expandedKeys.has(item.id);
-
-              const element: Element = {
-                id: item.id,
-                type: item.type,
-                parent_id: item.parent_id || null,
-                order_num: item.order_num,
-                props: item.props as ElementProps,
-                deleted: item.deleted,
-                layout_id: currentFrame?.id || null,
-                page_id: null,
-                created_at: "",
-                updated_at: "",
-              };
-
-              return (
-                <div
-                  key={item.id}
-                  data-depth={currentDepth}
-                  data-has-children={hasChildNodes}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onClick(element);
-                  }}
-                  className="element"
-                >
-                  <div
-                    className={`elementItem ${
-                      selectedElementId === item.id ? "active" : ""
-                    }`}
-                  >
-                    <div
-                      className="elementItemIndent"
-                      style={{
-                        width:
-                          currentDepth > 0 ? `${currentDepth * 8}px` : "0px",
-                      }}
-                    ></div>
-                    <div
-                      className="elementItemIcon"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (hasChildNodes) {
-                          toggleKey(item.id);
-                        }
-                      }}
-                    >
-                      {hasChildNodes ? (
-                        <ChevronRight
-                          color={iconProps.color}
-                          strokeWidth={iconProps.strokeWidth}
-                          size={iconProps.size}
-                          style={{
-                            transform: isExpanded
-                              ? "rotate(90deg)"
-                              : "rotate(0deg)",
-                          }}
-                        />
-                      ) : (
-                        <Box
-                          color={iconProps.color}
-                          strokeWidth={iconProps.strokeWidth}
-                          size={iconProps.size}
-                          style={{ padding: "2px" }}
-                        />
-                      )}
-                    </div>
-                    <div className="elementItemLabel">
-                      {item.type === "Slot" && item.props
-                        ? `Slot: ${
-                            (item.props as Record<string, unknown>).name ||
-                            "unnamed"
-                          }`
-                        : item.type}
-                    </div>
-                    <div className="elementItemActions">
-                      {item.type === "body" && (
-                        <button className="iconButton" aria-label="Settings">
-                          <Settings2
-                            color={iconProps.color}
-                            strokeWidth={iconProps.strokeWidth}
-                            size={iconProps.size}
-                          />
-                        </button>
-                      )}
-                      {item.type !== "body" && (
-                        <button
-                          className="iconButton"
-                          aria-label={`Delete ${item.type}`}
-                          onClick={async (e) => {
-                            e.stopPropagation();
-                            await onDelete(element);
-                          }}
-                        >
-                          <Trash
-                            color={iconProps.color}
-                            strokeWidth={iconProps.strokeWidth}
-                            size={iconProps.size}
-                          />
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                  {isExpanded &&
-                    hasChildNodes &&
-                    item.children &&
-                    renderTree(item.children, currentDepth + 1)}
-                </div>
-              );
-            })}
-          </>
-        );
-      };
-
-      return renderTree(tree, depth);
-    },
-    [expandedKeys, toggleKey, selectedElementId, currentFrame?.id],
-  );
-
   // Frame 선택 핸들러 — id 기반 (ADR-911 P2-a PR-B)
   const handleSelectFrame = useCallback(
     async (frameId: string) => {
@@ -452,43 +313,22 @@ export function FramesTab({
         onAdd={handleAddFrame}
       />
 
-      {/* Frame Element Tree */}
-      <div className="sidebar_elements">
-        <div className="panel-header">
-          <h3 className="panel-title">Layers</h3>
-          <div className="header-actions">
-            <button
-              className="iconButton"
-              aria-label="Collapse All"
-              onClick={() => collapseFrameTree()}
-            >
-              <Minimize
-                color={iconProps.color}
-                strokeWidth={iconProps.strokeWidth}
-                size={iconProps.size}
-              />
-            </button>
-          </div>
-        </div>
-        <div className="elements">
-          {!currentFrame ? (
-            <p className="no_element">Select a frame to view elements</p>
-          ) : frameElements.length === 0 ? (
-            <p className="no_element">No elements in this frame</p>
-          ) : (
-            renderFrameTree(
-              frameElementTree,
-              (el) => {
-                setSelectedElement(el.id, el.props as ElementProps);
-                requestAnimationFrame(() =>
-                  sendElementSelectedMessage(el.id, el.props as ElementProps),
-                );
-              },
-              handleDeleteElement,
-            )
-          )}
-        </div>
-      </div>
+      {/* Frame Element Tree — ADR-911 P2 PR-D2 추출 */}
+      <FrameElementTree
+        tree={frameElementTree}
+        frameId={currentFrame?.id ?? null}
+        selectedElementId={selectedElementId}
+        expandedKeys={expandedKeys}
+        toggleKey={toggleKey}
+        onCollapseAll={collapseFrameTree}
+        onElementClick={(el) => {
+          setSelectedElement(el.id, el.props as ElementProps);
+          requestAnimationFrame(() =>
+            sendElementSelectedMessage(el.id, el.props as ElementProps),
+          );
+        }}
+        onElementDelete={handleDeleteElement}
+      />
     </div>
   );
 }

--- a/apps/builder/src/builder/panels/nodes/FramesTab/__tests__/FrameElementTree.test.tsx
+++ b/apps/builder/src/builder/panels/nodes/FramesTab/__tests__/FrameElementTree.test.tsx
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+/**
+ * ADR-911 Phase 2 PR-D2 — FrameElementTree 컴포넌트 단위 테스트.
+ *
+ * 본 테스트는 FrameElementTree 가 프레젠테이션 전용임을 검증한다 — element
+ * 선택 / 삭제 핸들러 구현은 외부 책임이고, FrameElementTree 는 props 만으로
+ * 결정적 UI 를 렌더한다.
+ *
+ * 시나리오:
+ *  1. frameId=null → "Select a frame to view elements" placeholder
+ *  2. frameId=string + tree=[] → "No elements in this frame" placeholder
+ *  3. tree 1-level 렌더 → element type 표시
+ *  4. tree nested + expandedKeys → 자식 노드 렌더
+ *  5. tree nested + 미펼침 → 자식 노드 미렌더
+ *  6. element click → onElementClick(element) 호출 + frameId 매핑
+ *  7. element 'body' type → Settings 버튼 (Delete 없음)
+ *  8. element non-body delete → onElementDelete(element)
+ *  9. ChevronRight icon click → toggleKey(id)
+ * 10. Collapse All → onCollapseAll
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, screen, cleanup } from "@testing-library/react";
+
+import { FrameElementTree } from "../FrameElementTree";
+import type { ElementTreeItem } from "@/types/builder/stately.types";
+
+function makeItem(
+  id: string,
+  type: string,
+  override: Partial<ElementTreeItem> = {},
+): ElementTreeItem {
+  return {
+    id,
+    type,
+    parent_id: null,
+    order_num: 0,
+    props: {},
+    deleted: false,
+    children: [],
+    ...override,
+  } as ElementTreeItem;
+}
+
+function makeProps(
+  override: Partial<React.ComponentProps<typeof FrameElementTree>> = {},
+): React.ComponentProps<typeof FrameElementTree> {
+  return {
+    tree: [],
+    frameId: "frame-1",
+    selectedElementId: null,
+    expandedKeys: new Set<string>(),
+    toggleKey: vi.fn(),
+    onCollapseAll: vi.fn(),
+    onElementClick: vi.fn(),
+    onElementDelete: vi.fn(),
+    ...override,
+  };
+}
+
+describe("FrameElementTree (ADR-911 P2 PR-D2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("placeholder rendering", () => {
+    it("frameId=null → 'Select a frame to view elements' 표시", () => {
+      render(<FrameElementTree {...makeProps({ frameId: null })} />);
+      expect(screen.getByText("Select a frame to view elements")).toBeTruthy();
+    });
+
+    it("frameId 있고 tree=[] → 'No elements in this frame' 표시", () => {
+      render(<FrameElementTree {...makeProps({ frameId: "f-1", tree: [] })} />);
+      expect(screen.getByText("No elements in this frame")).toBeTruthy();
+    });
+  });
+
+  describe("tree rendering", () => {
+    it("tree 1-level → element type 표시", () => {
+      render(
+        <FrameElementTree
+          {...makeProps({
+            tree: [makeItem("el-1", "Button"), makeItem("el-2", "Text")],
+          })}
+        />,
+      );
+      expect(screen.getByText("Button")).toBeTruthy();
+      expect(screen.getByText("Text")).toBeTruthy();
+    });
+
+    it("Slot type → 'Slot: <name>' 형태로 표시", () => {
+      render(
+        <FrameElementTree
+          {...makeProps({
+            tree: [
+              makeItem("slot-1", "Slot", { props: { name: "header" } }),
+              makeItem("slot-2", "Slot", { props: {} }),
+            ],
+          })}
+        />,
+      );
+      expect(screen.getByText("Slot: header")).toBeTruthy();
+      expect(screen.getByText("Slot: unnamed")).toBeTruthy();
+    });
+
+    it("nested tree + expandedKeys 매칭 시 자식 표시", () => {
+      const parent = makeItem("parent", "Container", {
+        children: [makeItem("child", "Button")],
+      });
+      render(
+        <FrameElementTree
+          {...makeProps({
+            tree: [parent],
+            expandedKeys: new Set(["parent"]),
+          })}
+        />,
+      );
+      expect(screen.getByText("Container")).toBeTruthy();
+      expect(screen.getByText("Button")).toBeTruthy();
+    });
+
+    it("nested tree + expandedKeys 미매칭 시 자식 미표시", () => {
+      const parent = makeItem("parent", "Container", {
+        children: [makeItem("child", "Button")],
+      });
+      render(
+        <FrameElementTree
+          {...makeProps({ tree: [parent], expandedKeys: new Set() })}
+        />,
+      );
+      expect(screen.getByText("Container")).toBeTruthy();
+      expect(screen.queryByText("Button")).toBeNull();
+    });
+
+    it("selectedElementId 매칭 시 active 클래스 적용", () => {
+      const { container } = render(
+        <FrameElementTree
+          {...makeProps({
+            tree: [makeItem("el-1", "Button"), makeItem("el-2", "Text")],
+            selectedElementId: "el-1",
+          })}
+        />,
+      );
+      const items = container.querySelectorAll(".elementItem");
+      expect(items[0].className).toContain("active");
+      expect(items[1].className).not.toContain("active");
+    });
+  });
+
+  describe("interactions", () => {
+    it("element click → onElementClick(element) 호출 + frameId 가 element.layout_id 로 매핑", () => {
+      const onElementClick = vi.fn();
+      render(
+        <FrameElementTree
+          {...makeProps({
+            tree: [makeItem("el-1", "Button")],
+            frameId: "frame-abc",
+            onElementClick,
+          })}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Button"));
+
+      expect(onElementClick).toHaveBeenCalledTimes(1);
+      const element = onElementClick.mock.calls[0][0];
+      expect(element.id).toBe("el-1");
+      expect(element.type).toBe("Button");
+      expect(element.layout_id).toBe("frame-abc");
+      expect(element.page_id).toBeNull();
+    });
+
+    it("non-body Delete 버튼 클릭 → onElementDelete(element) + stopPropagation", async () => {
+      const onElementClick = vi.fn();
+      const onElementDelete = vi.fn().mockResolvedValue(undefined);
+      render(
+        <FrameElementTree
+          {...makeProps({
+            tree: [makeItem("el-1", "Button")],
+            onElementClick,
+            onElementDelete,
+          })}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Delete Button" }));
+      await Promise.resolve();
+
+      expect(onElementDelete).toHaveBeenCalledTimes(1);
+      expect(onElementDelete.mock.calls[0][0].id).toBe("el-1");
+      expect(onElementClick).not.toHaveBeenCalled();
+    });
+
+    it("body type → Settings 버튼 표시 (Delete 없음)", () => {
+      render(
+        <FrameElementTree
+          {...makeProps({ tree: [makeItem("body-1", "body")] })}
+        />,
+      );
+      expect(screen.getByRole("button", { name: "Settings" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: /^Delete/ })).toBeNull();
+    });
+
+    it("ChevronRight 아이콘 click (자식 있는 노드) → toggleKey(id) + stopPropagation", () => {
+      const toggleKey = vi.fn();
+      const onElementClick = vi.fn();
+      const parent = makeItem("parent", "Container", {
+        children: [makeItem("child", "Button")],
+      });
+      const { container } = render(
+        <FrameElementTree
+          {...makeProps({ tree: [parent], toggleKey, onElementClick })}
+        />,
+      );
+
+      // elementItemIcon 영역 클릭 (자식 있을 때 ChevronRight 가 렌더됨)
+      const iconWrapper = container.querySelector(".elementItemIcon");
+      fireEvent.click(iconWrapper!);
+
+      expect(toggleKey).toHaveBeenCalledWith("parent");
+      expect(onElementClick).not.toHaveBeenCalled();
+    });
+
+    it("Collapse All 버튼 클릭 → onCollapseAll", () => {
+      const onCollapseAll = vi.fn();
+      render(<FrameElementTree {...makeProps({ onCollapseAll })} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Collapse All" }));
+
+      expect(onCollapseAll).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ADR-911 Phase 2 PR-D2 — FrameElementTree 컴포넌트 분리 — 세션 37 후반] - 2026-04-27
+
+### Architecture
+
+- **ADR-911 Phase 2 PR-D2 — FrameElementTree 프레젠테이션 컴포넌트 추출** (functional 동등):
+  - `apps/builder/src/builder/panels/nodes/FramesTab/FrameElementTree.tsx` 신규 (~205 lines)
+    - props: `tree` / `frameId` / `selectedElementId` / `expandedKeys` / `toggleKey` / `onCollapseAll` / `onElementClick` / `onElementDelete`
+    - 책임: Layers 헤더 + Collapse All 버튼 + element 트리 렌더 + placeholder (frameId null / 빈 tree)
+    - 내부 `renderTree` 재귀 — `renderFrameTree` 함수 흡수 (FramesTab 의 useCallback 제거)
+  - `FramesTab.tsx` 의 `renderFrameTree` (135 lines) + `sidebar_elements` JSX (35 lines) → `<FrameElementTree>` 호출 (15 lines)
+  - 미사용 import 제거: lucide icons (`Minimize`/`ChevronRight`/`Box`/`Trash`/`Settings2`) + `iconProps` + `ElementTreeItem`
+  - **Why**: PR-D 의 FrameList 분리에 이어 FramesTab 이 orchestrator 역할만 남도록 UI 책임 완전 분리. `renderFrameTree` 가 더 이상 `useCallback` 으로 부모 hook deps 에 묶이지 않아 메모이제이션 부담 감소 (이전 deps: `[expandedKeys, toggleKey, selectedElementId, currentFrame?.id]`). PR-E 진입 시 동일 컴포넌트가 page-bound element tree 같은 다른 consumer 에 재사용 가능
+  - 검증: vitest 33/33 PASS (FrameList 6 + FrameElementTree 12 + FramesTab 8 + frameActions 7) / type-check 0
+
+### Infrastructure
+
+- **FrameElementTree vitest 신규** (12 시나리오):
+  - `__tests__/FrameElementTree.test.tsx` — 프레젠테이션 단위 테스트 (mock 0 — props 순수 함수)
+  - placeholder 2: frameId null → "Select a frame" / tree=[] → "No elements"
+  - tree 렌더 5: 1-level 표시 / Slot type "Slot: name" 명명 / nested expanded → 자식 표시 / nested collapsed → 자식 미표시 / selectedElementId active 클래스
+  - interactions 5: element click → onElementClick(element) + frameId가 element.layout_id 로 매핑 / non-body Delete → onElementDelete + stopPropagation / body type → Settings 버튼 (Delete 없음) / ChevronRight icon click → toggleKey + stopPropagation / Collapse All → onCollapseAll
+  - **Why**: 컴포넌트 분리 시점에 결정적 UI 계약을 잠금. P3 cascade 재작성 시 element tree 동작이 보존되는지 즉시 감지
+
 ## [ADR-911 Phase 2 PR-D — FrameList 컴포넌트 분리 — 세션 37 후반] - 2026-04-27
 
 ### Architecture

--- a/docs/adr/911-layout-frameset-pencil-redesign.md
+++ b/docs/adr/911-layout-frameset-pencil-redesign.md
@@ -28,13 +28,19 @@ In Progress — 2026-04-26 → 2026-04-27
   - **selector cache 함정 회피** (memory: `feedback-zustand-selector-cache.md`): useMemo 안에서 `useStore.getState()` 호출. selector 등록 안 함. deps: `[layouts, pages, elementsMap]`
   - `currentFrame` / `handleAddFrame.layouts.length+1` / `handleDeleteFrame.remaining` / JSX `layouts.map → reusableFrames.map` 모두 `reusableFrames` 기반으로 통일
   - vitest 8/8 PASS (5 legacy baseline + 3 canonical mode: 목록 표시 / non-frame 필터 / id 정규화) + type-check 0 + frameActions 회귀 0
-- **2026-04-27 (세션 37 후속)**: **PR-D: FrameList 컴포넌트 분리** (functional 동등, PR pending)
+- **2026-04-27 (세션 37 후속)**: **PR-D: FrameList 컴포넌트 분리** (functional 동등, PR #254 / `b391c42a`)
   - `FrameList.tsx` 신규 — frame 목록 + Add/Delete 버튼 (props: `frames` / `selectedFrameId` / `onSelect` / `onDelete` / `onAdd`)
   - `FramesTab.tsx` 의 `sidebar_layouts` JSX 영역 (62 lines) 을 `<FrameList>` 컴포넌트로 교체. `CirclePlus` import 제거
   - `__tests__/FrameList.test.tsx` 신규 (6 시나리오: 빈 / 2개 렌더 / active 클래스 / Add / Select / Delete + stopPropagation)
   - 검증: vitest 14/14 PASS (FrameList 6 + FramesTab 8) / frameActions 7/7 (회귀 0) / type-check 0
   - **Why**: 프레젠테이션 분리 — 데이터 source (legacy/canonical) 결정과 frame CRUD 로직은 부모 책임, FrameList 는 props 기반 결정적 UI 만 담당. PR-E 진입 시 동일 컴포넌트 재사용 가능
-- **잔여 Phase 2 sub-PR**: PR-D2 (FrameElementTree 분리, optional) / PR-E (PageLayoutSelector + dev migration trigger + dual-mode flag 활성화)
+- **2026-04-27 (세션 37 후속)**: **PR-D2: FrameElementTree 컴포넌트 분리** (functional 동등, PR pending)
+  - `FrameElementTree.tsx` 신규 — Layers 헤더 + Collapse All 버튼 + tree 렌더 + placeholder. `renderFrameTree` 함수 흡수. props: `tree` / `frameId` / `selectedElementId` / `expandedKeys` / `toggleKey` / `onCollapseAll` / `onElementClick` / `onElementDelete`
+  - `FramesTab.tsx` 의 `renderFrameTree` (135 lines) + `sidebar_elements` JSX (35 lines) → `<FrameElementTree>` 호출 (15 lines). lucide icons (`Minimize`/`ChevronRight`/`Box`/`Trash`/`Settings2`) + `iconProps` + `ElementTreeItem` import 제거
+  - `__tests__/FrameElementTree.test.tsx` 신규 (12 시나리오): placeholder 2 (frameId null / tree 빈) / tree 렌더 5 (1-level / Slot 명명 / nested expanded / nested collapsed / active) / interactions 5 (element click + frameId 매핑 / Delete + stopPropagation / body Settings / ChevronRight toggle / Collapse All)
+  - 검증: vitest 33/33 PASS (FrameList 6 + FrameElementTree 12 + FramesTab 8 + frameActions 7) / type-check 0
+  - **Why**: FramesTab 이 orchestrator 역할만 남도록 UI 책임 완전 분리. `renderFrameTree` 가 더 이상 `useCallback` 으로 부모 hook deps 에 묶이지 않아 메모이제이션 부담 감소. PR-E 진입 시 `<FrameElementTree>` 가 page-bound element tree 같은 다른 consumer 에 재사용 가능
+- **잔여 Phase 2 sub-PR**: PR-E (PageLayoutSelector + dev migration trigger + dual-mode flag 활성화) — Phase 2 cutover 마지막 단계
 
 ## Context
 

--- a/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
+++ b/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
@@ -445,7 +445,8 @@ const handleDevMigrate = useCallback(async () => {
 | **A**  | `frameActions.ts` skeleton (legacy wrapper) + `isFramesTabCanonical()` flag 추가 (default false)       | P2-a 부분 + P2-d | ✅ 2026-04-27 main land (`e9e388ca`) |
 | **B**  | `FramesTab.handleAddFrame/handleDeleteFrame/handleSelectFrame` → `frameActions` 위임 (functional 동등) | P2-a 잔여        | ✅ 2026-04-27 (PR pending)           |
 | **C**  | read path canonical 전환 — `selectCanonicalDocument` + `useMemo`/`getState` 패턴                       | P2-a 잔여        | ✅ 2026-04-27 (PR pending)           |
-| **D**  | `FrameList` 분리 (FrameDetails / SlotList 는 D2/E 로 deferred)                                         | P2-b             | ✅ 2026-04-27 (PR pending)           |
+| **D**  | `FrameList` 분리 (FrameDetails / SlotList 는 D2/E 로 deferred)                                         | P2-b             | ✅ 2026-04-27 main land (`b391c42a`) |
+| **D2** | `FrameElementTree` 분리 — Layers 헤더 + tree 렌더 + placeholder                                        | P2-b 잔여        | ✅ 2026-04-27 (PR pending)           |
 | **E**  | `PageLayoutSelector` 재작성 + `usePresetApply` canonical mutation + dev migration trigger              | P2-c + P2-e      | 후속 세션                            |
 | **G**  | parallel-verify 25/25 + 1주 dual-mode + cutover                                                        | P2-f + P2-g      | 후속 세션                            |
 


### PR DESCRIPTION
FrameElementTree.tsx 신규 — Layers 헤더 + Collapse All + tree 렌더 + placeholder. renderFrameTree 함수 흡수. props: tree / frameId / selectedElementId / expandedKeys / toggleKey / onCollapseAll / onElementClick / onElementDelete.

FramesTab.tsx 의 renderFrameTree (135줄) + sidebar_elements JSX (35줄) → <FrameElementTree> 호출 (15줄). 미사용 import 제거: lucide icons 5개 + iconProps + ElementTreeItem.

FrameElementTree vitest 12/12 PASS (mock 0):
- placeholder 2: frameId null / tree=[] 빈
- tree 렌더 5: 1-level / Slot 명명 / nested expanded / nested collapsed / active
- interactions 5: element click + frameId 매핑 / Delete + stopPropagation / body Settings / ChevronRight toggle / Collapse All

Why: PR-D 의 FrameList 분리에 이어 FramesTab 이 orchestrator 역할만 남도록 UI 책임 완전 분리. renderFrameTree 가 useCallback 으로 부모 hook deps ([expandedKeys, toggleKey, selectedElementId, currentFrame?.id])에 묶이지 않아 메모이제이션 부담 감소. PR-E 진입 시 page-bound element tree 같은 다른 consumer 에 재사용 가능.

검증: vitest 33/33 PASS (FrameList 6 + FrameElementTree 12 + FramesTab 8 + frameActions 7) / type-check 0.