### PR TITLE
feat(adr-911-p2-e1): PageLayoutSelector dual-mode read 전환 (functional…

### DIFF
--- a/apps/builder/src/adapters/canonical/slotAndLayoutAdapter.ts
+++ b/apps/builder/src/adapters/canonical/slotAndLayoutAdapter.ts
@@ -197,6 +197,8 @@ export function convertLayoutToReusableFrame(
       type: "legacy-layout",
       layoutId: layout.id,
       slug: layout.slug ?? null,
+      // ADR-911 P2 PR-E1: PageLayoutSelector canonical mode 에서 description 표시 보존
+      description: layout.description ?? null,
     },
     children: rootElements.map((el) =>
       convertElementWithSlotHoisting(

--- a/apps/builder/src/builder/panels/properties/editors/PageLayoutSelector.tsx
+++ b/apps/builder/src/builder/panels/properties/editors/PageLayoutSelector.tsx
@@ -2,23 +2,31 @@
  * Page Layout Selector
  *
  * ADR-903 P3-C: page 의 layout 연결 → page 노드의 reusable frame ref 선택 UI.
+ * ADR-911 P2 PR-E1: read path dual-mode (`isFramesTabCanonical()` flag 분기).
  *
- * P3-C 변경:
- * - frame 목록: `useLayouts()` hook (P3-B canonical surface)
- * - `layout_id` read: page.layout_id (legacy field — P3-D 에서 canonical ref로 전환)
- * - `useLayoutsStore` 직접 접근 제거: `useLayouts` + `useFetchLayouts` hook 사용
+ * - **legacy path** (default false): `useLayouts()` hook (P3-B canonical surface)
+ * - **canonical path** (true): `selectCanonicalDocument` 의 reusable FrameNode 추출
+ *   (PR-C FramesTab 과 동일한 패턴 — selector cache 함정 회피용 useMemo + getState)
  *
- * @deprecated-path `useLayoutsStore` direct access → `useLayouts` / `useFetchLayouts`
+ * id 정규화: canonical FrameNode.id 는 `"layout-<legacyId>"` 접두사 → `metadata.layoutId`
+ * 우선 사용. legacy `page.layout_id` 와 정합 유지.
+ *
+ * write (`handleLayoutChange`) 는 legacy 그대로 — `pages.update(layout_id)` 직접 호출.
+ * P3-D 이후 canonical document mutation (page RefNode.ref 변경) 으로 전환.
+ *
+ * @deprecated-path `useLayoutsStore` direct access → `useLayouts` / dual-mode reusableFrames
  */
 
 import { memo, useMemo, useCallback, useEffect } from "react";
 import { Layout, X } from "lucide-react";
 import { PropertySelect, PropertySection } from "../../../components";
-import { useLayouts } from "../../../stores/layouts";
+import { useLayouts, useLayoutsStore } from "../../../stores/layouts";
 import { useStore } from "../../../stores";
+import { selectCanonicalDocument } from "../../../stores/elements";
 import { getDB } from "../../../../lib/db";
 import { iconEditProps } from "../../../../utils/ui/uiConstants";
-import { useLayoutsStore } from "../../../stores/layouts";
+import { isFramesTabCanonical } from "../../../../utils/featureFlags";
+import type { FrameNode } from "@composition/shared";
 
 interface PageLayoutSelectorProps {
   pageId: string;
@@ -41,20 +49,54 @@ export const PageLayoutSelector = memo(function PageLayoutSelector({
     }
   }, [layouts.length, fetchLayouts, page?.project_id]);
 
+  // ADR-911 P2 PR-E1: dual-mode read path (PR-C FramesTab 패턴 동일).
+  // selector cache 함정 회피 — useMemo 안에서 useStore.getState() 호출.
+  const elementsMap = useStore((state) => state.elementsMap);
+  const pages = useStore((state) => state.pages);
+  const reusableFrames = useMemo<
+    ReadonlyArray<{ id: string; name: string; description?: string }>
+  >(() => {
+    if (!isFramesTabCanonical()) {
+      return layouts.map((l) => ({
+        id: l.id,
+        name: l.name,
+        description: l.description,
+      }));
+    }
+    const state = useStore.getState();
+    const doc = selectCanonicalDocument(state, pages, layouts);
+    return doc.children
+      .filter(
+        (n): n is FrameNode =>
+          n.type === "frame" && (n as FrameNode).reusable === true,
+      )
+      .map((f) => {
+        const meta = f.metadata as
+          | { layoutId?: string; description?: string }
+          | undefined;
+        return {
+          id: meta?.layoutId ?? f.id,
+          name: f.name ?? "",
+          description: meta?.description,
+        };
+      });
+    // elementsMap 변경 시 canonical projection 도 갱신 (selectCanonicalDocument 가 elements 소비)
+  }, [layouts, pages, elementsMap]);
+
   // P3-C: page.layout_id는 legacy field — P3-D에서 canonical ref로 전환 예정
   const currentLayoutId = page?.layout_id || "";
   const currentLayout = useMemo(
-    () => layouts.find((l) => l.id === currentLayoutId),
-    [layouts, currentLayoutId],
+    () => reusableFrames.find((f) => f.id === currentLayoutId),
+    [reusableFrames, currentLayoutId],
   );
 
   const layoutOptions = useMemo(() => {
     const options = [{ value: "", label: "No Frame" }];
-    layouts.forEach((layout) => {
-      options.push({ value: layout.id, label: layout.name });
+    reusableFrames.forEach((frame) => {
+      options.push({ value: frame.id, label: frame.name });
     });
     return options;
-  }, [layouts]);
+  }, [reusableFrames]);
 
   const handleLayoutChange = useCallback(
     async (layoutId: string) => {
@@ -84,7 +126,7 @@ export const PageLayoutSelector = memo(function PageLayoutSelector({
     [pageId],
   );
 
-  if (layouts.length === 0) return null;
+  if (reusableFrames.length === 0) return null;
 
   return (
     <PropertySection title="Frame" icon={Layout}>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ADR-911 Phase 2 PR-E1 — PageLayoutSelector dual-mode read 전환 — 세션 37 후반] - 2026-04-27
+
+### Architecture
+
+- **ADR-911 Phase 2 PR-E1 — PageLayoutSelector dual-mode read 전환** (functional 동등):
+  - `apps/builder/src/builder/panels/properties/editors/PageLayoutSelector.tsx`
+    - `isFramesTabCanonical()` flag 기반 dual-mode read path 도입 (PR-C FramesTab 패턴 동일)
+      - **legacy path** (default false): `useLayouts()` 결과 그대로 사용
+      - **canonical path** (true): `selectCanonicalDocument(state, pages, layouts).children.filter(reusable: true).map(...)` — `metadata.layoutId` 로 id 정규화하여 legacy `page.layout_id` 와 정합
+    - `reusableFrames` useMemo 도입 — selector cache 함정 회피 (`useStore.getState()` 호출, deps `[layouts, pages, elementsMap]`)
+    - `currentLayout` / `layoutOptions` / `layouts.length === 0` 가드 모두 `reusableFrames` 단일 source 기반으로 통일
+    - write (`handleLayoutChange`) 는 legacy 그대로 — `pages.update(layout_id)` 직접 호출. P3-D 이후 canonical document mutation (RefNode.ref 변경) 으로 전환
+  - **Why**: PR-C 에서 FramesTab read 를 canonical 로 전환했지만, PageLayoutSelector 는 여전히 legacy `useLayouts()` 직접 소비 → flag 활성화 시 두 컴포넌트의 frame 표시 mismatch 가능. PR-E1 이 그 정합성 복구. PR-E4 cutover (`VITE_FRAMES_TAB_CANONICAL=true` default) 시 두 컴포넌트가 동일 source 사용 보장
+  - 검증: type-check 0 / FramesTab 33/33 회귀 0 / canonical adapters 78/78 회귀 0
+
+### Bug Fixes
+
+- **canonical mode 에서 PageLayoutSelector description 회귀 방지** (PR-E1 동반):
+  - `apps/builder/src/adapters/canonical/slotAndLayoutAdapter.ts::convertLayoutToReusableFrame` 의 `metadata` 에 `description: layout.description ?? null` 보존 추가
+  - **Why**: legacy `Layout.description` 은 PageLayoutSelector 의 "Using <name> frame" + description 표시에 사용. canonical projection 시 description 미보존 → flag 활성화 시 description UI 사라짐 회귀. metadata 에 보존하여 양 mode 시각 동일 유지
+
 ## [ADR-911 Phase 2 PR-D2 — FrameElementTree 컴포넌트 분리 — 세션 37 후반] - 2026-04-27
 
 ### Architecture

--- a/docs/adr/911-layout-frameset-pencil-redesign.md
+++ b/docs/adr/911-layout-frameset-pencil-redesign.md
@@ -34,13 +34,21 @@ In Progress — 2026-04-26 → 2026-04-27
   - `__tests__/FrameList.test.tsx` 신규 (6 시나리오: 빈 / 2개 렌더 / active 클래스 / Add / Select / Delete + stopPropagation)
   - 검증: vitest 14/14 PASS (FrameList 6 + FramesTab 8) / frameActions 7/7 (회귀 0) / type-check 0
   - **Why**: 프레젠테이션 분리 — 데이터 source (legacy/canonical) 결정과 frame CRUD 로직은 부모 책임, FrameList 는 props 기반 결정적 UI 만 담당. PR-E 진입 시 동일 컴포넌트 재사용 가능
-- **2026-04-27 (세션 37 후속)**: **PR-D2: FrameElementTree 컴포넌트 분리** (functional 동등, PR pending)
+- **2026-04-27 (세션 37 후속)**: **PR-D2: FrameElementTree 컴포넌트 분리** (functional 동등, PR #255 / `604b11f3`)
   - `FrameElementTree.tsx` 신규 — Layers 헤더 + Collapse All 버튼 + tree 렌더 + placeholder. `renderFrameTree` 함수 흡수. props: `tree` / `frameId` / `selectedElementId` / `expandedKeys` / `toggleKey` / `onCollapseAll` / `onElementClick` / `onElementDelete`
   - `FramesTab.tsx` 의 `renderFrameTree` (135 lines) + `sidebar_elements` JSX (35 lines) → `<FrameElementTree>` 호출 (15 lines). lucide icons (`Minimize`/`ChevronRight`/`Box`/`Trash`/`Settings2`) + `iconProps` + `ElementTreeItem` import 제거
   - `__tests__/FrameElementTree.test.tsx` 신규 (12 시나리오): placeholder 2 (frameId null / tree 빈) / tree 렌더 5 (1-level / Slot 명명 / nested expanded / nested collapsed / active) / interactions 5 (element click + frameId 매핑 / Delete + stopPropagation / body Settings / ChevronRight toggle / Collapse All)
   - 검증: vitest 33/33 PASS (FrameList 6 + FrameElementTree 12 + FramesTab 8 + frameActions 7) / type-check 0
   - **Why**: FramesTab 이 orchestrator 역할만 남도록 UI 책임 완전 분리. `renderFrameTree` 가 더 이상 `useCallback` 으로 부모 hook deps 에 묶이지 않아 메모이제이션 부담 감소. PR-E 진입 시 `<FrameElementTree>` 가 page-bound element tree 같은 다른 consumer 에 재사용 가능
-- **잔여 Phase 2 sub-PR**: PR-E (PageLayoutSelector + dev migration trigger + dual-mode flag 활성화) — Phase 2 cutover 마지막 단계
+- **2026-04-27 (세션 37 후속)**: **PR-E1: PageLayoutSelector dual-mode read 전환** (functional 동등, PR pending)
+  - `PageLayoutSelector.tsx` 의 read path 를 PR-C FramesTab 패턴 동일하게 dual-mode 전환 — `isFramesTabCanonical()` flag 분기
+    - **legacy path** (default false): `useLayouts()` hook 결과 그대로 사용
+    - **canonical path** (true): `selectCanonicalDocument(state, pages, layouts).children.filter(reusable: true)` — `metadata.layoutId` 로 id 정규화하여 legacy `page.layout_id` 와 정합 유지
+  - **selector cache 함정 회피**: useMemo 안에서 `useStore.getState()` 호출. deps: `[layouts, pages, elementsMap]`
+  - `slotAndLayoutAdapter.convertLayoutToReusableFrame` 의 `metadata` 에 `description` 보존 추가 — canonical mode 에서 PageLayoutSelector 의 description 표시 회귀 방지
+  - write (`handleLayoutChange`) 는 그대로 — `pages.update(layout_id)` legacy 직접 호출. P3-D 이후 canonical document mutation (RefNode.ref 변경) 으로 전환
+  - 검증: type-check 0 / FramesTab 33/33 회귀 0 / canonical adapters 78/78 회귀 0
+- **잔여 Phase 2 sub-PR**: PR-E2 (`usePresetApply.ts` canonical mutation) / PR-E3 (dev migration trigger + Chrome MCP P1-c roundtrip) / PR-E4 (1주 dual-mode + cutover, default flag true 전환)
 
 ## Context
 

--- a/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
+++ b/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
@@ -446,8 +446,11 @@ const handleDevMigrate = useCallback(async () => {
 | **B**  | `FramesTab.handleAddFrame/handleDeleteFrame/handleSelectFrame` → `frameActions` 위임 (functional 동등) | P2-a 잔여        | ✅ 2026-04-27 (PR pending)           |
 | **C**  | read path canonical 전환 — `selectCanonicalDocument` + `useMemo`/`getState` 패턴                       | P2-a 잔여        | ✅ 2026-04-27 (PR pending)           |
 | **D**  | `FrameList` 분리 (FrameDetails / SlotList 는 D2/E 로 deferred)                                         | P2-b             | ✅ 2026-04-27 main land (`b391c42a`) |
-| **D2** | `FrameElementTree` 분리 — Layers 헤더 + tree 렌더 + placeholder                                        | P2-b 잔여        | ✅ 2026-04-27 (PR pending)           |
-| **E**  | `PageLayoutSelector` 재작성 + `usePresetApply` canonical mutation + dev migration trigger              | P2-c + P2-e      | 후속 세션                            |
+| **D2** | `FrameElementTree` 분리 — Layers 헤더 + tree 렌더 + placeholder                                        | P2-b 잔여        | ✅ 2026-04-27 main land (`604b11f3`) |
+| **E1** | `PageLayoutSelector` dual-mode read 전환 + `slotAndLayoutAdapter` description 보존                     | P2-c 부분        | ✅ 2026-04-27 (PR pending)           |
+| **E2** | `usePresetApply.ts` canonical mutation 전환                                                            | P2-c 잔여        | 후속 세션                            |
+| **E3** | dev migration trigger (handleDevMigrate) + Chrome MCP P1-c roundtrip                                   | P2-e             | 후속 세션                            |
+| **E4** | 1주 dual-mode + cutover (`VITE_FRAMES_TAB_CANONICAL=true` default 전환)                                | P2-f + P2-g      | 후속 세션                            |
 | **G**  | parallel-verify 25/25 + 1주 dual-mode + cutover                                                        | P2-f + P2-g      | 후속 세션                            |
 
 | Step       | 내용                                                                                                                      | 시간 | RED/GREEN 사이클                                                                                     |


### PR DESCRIPTION
… 동등)

PR-C FramesTab 동일 패턴 — isFramesTabCanonical() flag 기반 read path dual-mode 전환:
- legacy: useLayouts() 결과 그대로 (default false)
- canonical: selectCanonicalDocument().children.filter(reusable: true)
  + metadata.layoutId 로 id 정규화

selector cache 함정 회피 (memory: feedback-zustand-selector-cache.md):
useMemo 안에서 useStore.getState() 호출. deps: [layouts, pages, elementsMap].

reusableFrames 단일 source 통일: currentLayout / layoutOptions / 빈 가드. write (handleLayoutChange) 는 legacy 유지 — pages.update(layout_id) 직접 호출. P3-D 이후 canonical document mutation 으로 전환.

slotAndLayoutAdapter.convertLayoutToReusableFrame 의 metadata 에 description 보존 추가 (functional 회귀 방지). canonical mode 활성화 시 PageLayoutSelector 의 description 표시 보존.

Why: PR-C 에서 FramesTab read 를 canonical 로 전환했지만 PageLayoutSelector 는 여전히 legacy useLayouts() 직접 소비 → flag 활성화 시 두 컴포넌트의 frame 표시 mismatch 가능. PR-E1 이 그 정합성 복구. PR-E4 cutover 시 두 컴포넌트가 동일 source 사용 보장.

검증: type-check 0 / FramesTab 33/33 회귀 0 / canonical adapters 78/78 회귀 0.