### PR TITLE
feat(adr-911-p2-e3): dev-only canonical migration trigger (P1-c round…

### DIFF
--- a/apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx
+++ b/apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx
@@ -40,6 +40,11 @@ import {
   isCanvasCompareMode,
   isFramesTabCanonical,
 } from "../../../../utils/featureFlags";
+import {
+  dryRunMigrationP911,
+  applyMigrationP911,
+  type MigrationP911Adapter,
+} from "../../../../lib/db/migrationP911";
 import type { FrameNode } from "@composition/shared";
 
 interface FramesTabProps {
@@ -297,6 +302,66 @@ export function FramesTab({
     [removeElement, selectedElementId, setSelectedElement, isWebGLOnly],
   );
 
+  // ADR-911 P2 PR-E3 / P1-c — dev-only canonical migration trigger.
+  // legacy `layouts[]` rows 중 canonical document 에 reusable FrameNode 로 hoist
+  // 되지 않은 것을 dryRun → apply (in-memory). persistence (DB write / store
+  // commit) 는 본 단계에서 미구현 — Chrome MCP roundtrip 결과 콘솔 검증 용도만.
+  // production code path 영향 0 (`process.env.NODE_ENV !== "development"` 단락).
+  const handleDevMigrate = useCallback(async () => {
+    if (process.env.NODE_ENV !== "development") return;
+    if (!projectId) {
+      console.warn("[ADR-911 P1-c] projectId 없음 — migration trigger 무시");
+      return;
+    }
+
+    try {
+      const db = await getDB();
+      const adapter: MigrationP911Adapter = {
+        layouts: { getByProject: (id) => db.layouts.getByProject(id) },
+      };
+      const state = useStore.getState();
+      const layoutsState = useLayoutsStore.getState().layouts;
+      const canonicalDoc = selectCanonicalDocument(
+        state,
+        state.pages,
+        layoutsState,
+      );
+
+      console.group("[ADR-911 P1-c] migration dry-run");
+      const result = await dryRunMigrationP911(
+        adapter,
+        projectId,
+        canonicalDoc,
+      );
+      console.info("status:", result.status);
+      console.info(
+        "hoisted:",
+        result.hoisted.length,
+        result.hoisted.map((f) => f.id),
+      );
+      console.info("skipped:", result.skipped.length, result.skipped);
+      console.info("errors:", result.errors);
+
+      if (result.errors.length === 0 && result.hoisted.length > 0) {
+        const newDoc = applyMigrationP911(canonicalDoc, result);
+        const reusableCount = newDoc.children.filter(
+          (n) => n.type === "frame" && (n as FrameNode).reusable === true,
+        ).length;
+        console.info("applied — new doc.children:", newDoc.children.length);
+        console.info("reusable frames after hoist:", reusableCount);
+        console.info(
+          "[note] persistence 미구현 — canonical store write API 도입 (P3-D) 후 commit 가능",
+        );
+      } else {
+        console.info("no apply (errors > 0 or hoist 후보 0)");
+      }
+      console.groupEnd();
+    } catch (error) {
+      console.error("[ADR-911 P1-c] dev migration error:", error);
+      console.groupEnd();
+    }
+  }, [projectId]);
+
   return (
     <div
       className="layouts-tab"
@@ -304,6 +369,32 @@ export function FramesTab({
       id="tabpanel-frames"
       aria-label="Frames"
     >
+      {/* ADR-911 P2 PR-E3 — dev-only canonical migration trigger.
+          production build 에서는 단락 (process.env.NODE_ENV === "development" 단락). */}
+      {process.env.NODE_ENV === "development" && (
+        <div
+          className="dev-tools"
+          style={{
+            padding: "4px 8px",
+            fontSize: "11px",
+            borderBottom: "1px solid var(--border-color, #ddd)",
+          }}
+        >
+          <button
+            type="button"
+            onClick={handleDevMigrate}
+            title="ADR-911 P1-c: dryRun + apply (in-memory, no persistence). 결과 콘솔 확인."
+            style={{
+              fontSize: "11px",
+              padding: "2px 6px",
+              cursor: "pointer",
+            }}
+          >
+            Dev: Migrate to Canonical
+          </button>
+        </div>
+      )}
+
       {/* Frames List — ADR-911 P2 PR-D 추출 */}
       <FrameList
         frames={reusableFrames}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ADR-911 Phase 2 PR-E3 — dev-only canonical migration trigger — 세션 37 후반] - 2026-04-27
+
+### Features
+
+- **ADR-911 P1-c — dev-only canonical migration trigger UI 추가**:
+  - `FramesTab.tsx` 에 "Dev: Migrate to Canonical" 버튼 + `handleDevMigrate` handler
+  - 동작: `dryRunMigrationP911(adapter, projectId, canonicalDoc)` 결과 콘솔 group 으로 출력 (status / hoisted ids / skipped / errors). errors 0 + hoisted > 0 시 `applyMigrationP911(canonicalDoc, result)` 로 in-memory apply 실행 + 결과 reusable frame 개수 로그
+  - production 단락: `process.env.NODE_ENV === "development"` 체크. production build 영향 0 (tree-shake 가능)
+  - **persistence 미구현**: canonical document store write API 가 없음 (P3-D 종속) — 본 trigger 는 Chrome MCP P1-c roundtrip dev 검증 용도만. 콘솔에 `"persistence 미구현 — canonical store write API 도입 (P3-D) 후 commit 가능"` 안내 출력
+  - **Why**: ADR-911 Phase 1 의 migration helper (`hoistLayoutAsReusableFrame` / `dryRun` / `apply`) 가 실 dev 데이터에 대해 정상 동작하는지 검증할 진입점 부재. P2-e (Chrome MCP P1-c roundtrip) 의 진입점 옵션 A (FramesTab dev menu) 채택. P3 진입 시 옵션 B (initializeProject 자동 trigger) 으로 교체 예정
+
+### Documentation
+
+- **ADR-911 PR-E2 skip 결정 + sub-PR 재배치**:
+  - `usePresetApply.ts` read 는 이미 `selectCanonicalDocument` 사용 (dual-mode 친화적). write (`type="Slot"` element + `addComplexElement`) 는 P3-D 의 canonical document write API 도입 후 별도 ADR 로 처리
+  - **Why**: Phase 2 cutover (read path dual-mode) 에 PR-E2 write 전환은 필수 아님. 사용자 시각 차이는 read level 에서만 dual-mode 분기로 충족. 무리한 write 전환은 P3-D 의존성으로 인해 incomplete 상태 land 위험
+  - sub-PR 표 갱신: E2 status `🔄 P3-D 종속 — 별도 ADR 로 처리`
+
 ## [ADR-911 Phase 2 PR-E1 — PageLayoutSelector dual-mode read 전환 — 세션 37 후반] - 2026-04-27
 
 ### Architecture

--- a/docs/adr/911-layout-frameset-pencil-redesign.md
+++ b/docs/adr/911-layout-frameset-pencil-redesign.md
@@ -48,7 +48,14 @@ In Progress — 2026-04-26 → 2026-04-27
   - `slotAndLayoutAdapter.convertLayoutToReusableFrame` 의 `metadata` 에 `description` 보존 추가 — canonical mode 에서 PageLayoutSelector 의 description 표시 회귀 방지
   - write (`handleLayoutChange`) 는 그대로 — `pages.update(layout_id)` legacy 직접 호출. P3-D 이후 canonical document mutation (RefNode.ref 변경) 으로 전환
   - 검증: type-check 0 / FramesTab 33/33 회귀 0 / canonical adapters 78/78 회귀 0
-- **잔여 Phase 2 sub-PR**: PR-E2 (`usePresetApply.ts` canonical mutation) / PR-E3 (dev migration trigger + Chrome MCP P1-c roundtrip) / PR-E4 (1주 dual-mode + cutover, default flag true 전환)
+- **2026-04-27 (세션 37 후속)**: **PR-E2 skip 결정** — `usePresetApply.ts` read 는 이미 `selectCanonicalDocument` 사용 (dual-mode 친화적). write (`type="Slot"` element + `addComplexElement`) 는 P3-D 의 canonical document write API 도입 후 별도 ADR 로 처리. Phase 2 cutover 에 필수 아님 (사용자 시각 차이 없음 — read level 에서만 dual-mode 분기).
+- **2026-04-27 (세션 37 후속)**: **PR-E3: dev-only canonical migration trigger** (PR pending)
+  - `FramesTab.tsx` 에 dev-only "Migrate to Canonical" 버튼 + `handleDevMigrate` handler 추가
+  - `dryRunMigrationP911(adapter, projectId, canonicalDoc)` + `applyMigrationP911(canonicalDoc, result)` (in-memory) 호출. 결과 콘솔 group 로그
+  - production 단락: `process.env.NODE_ENV === "development"` 체크. production build 영향 0
+  - **persistence 미구현**: canonical document store write API 가 없음 (P3-D 종속). Chrome MCP P1-c roundtrip dev 검증 용도만
+  - 검증: type-check 0 / FramesTab 33/33 회귀 0 / migrationP911 45/45 회귀 0 / db 전체 126/126 회귀 0
+- **잔여 Phase 2 sub-PR**: PR-E4 (1주 dual-mode + cutover, `VITE_FRAMES_TAB_CANONICAL=true` default 전환)
 
 ## Context
 

--- a/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
+++ b/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
@@ -448,8 +448,8 @@ const handleDevMigrate = useCallback(async () => {
 | **D**  | `FrameList` 분리 (FrameDetails / SlotList 는 D2/E 로 deferred)                                         | P2-b             | ✅ 2026-04-27 main land (`b391c42a`) |
 | **D2** | `FrameElementTree` 분리 — Layers 헤더 + tree 렌더 + placeholder                                        | P2-b 잔여        | ✅ 2026-04-27 main land (`604b11f3`) |
 | **E1** | `PageLayoutSelector` dual-mode read 전환 + `slotAndLayoutAdapter` description 보존                     | P2-c 부분        | ✅ 2026-04-27 (PR pending)           |
-| **E2** | `usePresetApply.ts` canonical mutation 전환                                                            | P2-c 잔여        | 후속 세션                            |
-| **E3** | dev migration trigger (handleDevMigrate) + Chrome MCP P1-c roundtrip                                   | P2-e             | 후속 세션                            |
+| **E2** | `usePresetApply.ts` canonical mutation 전환 (write 경로 P3-D 종속 — defer)                             | P2-c 잔여        | 🔄 P3-D 종속 — 별도 ADR 로 처리      |
+| **E3** | dev migration trigger (handleDevMigrate) + Chrome MCP P1-c roundtrip                                   | P2-e             | ✅ 2026-04-27 (PR pending)           |
 | **E4** | 1주 dual-mode + cutover (`VITE_FRAMES_TAB_CANONICAL=true` default 전환)                                | P2-f + P2-g      | 후속 세션                            |
 | **G**  | parallel-verify 25/25 + 1주 dual-mode + cutover                                                        | P2-f + P2-g      | 후속 세션                            |
 


### PR DESCRIPTION
…trip)

FramesTab.tsx 에 dev-only "Migrate to Canonical" 버튼 + handleDevMigrate 추가. dryRunMigrationP911 + applyMigrationP911 (in-memory) 호출, 결과 콘솔 group 출력.

production 단락: process.env.NODE_ENV === "development" 체크. production build 영향 0 (tree-shake 가능).

persistence 미구현: canonical document store write API 부재 (P3-D 종속). 본 trigger 는 Chrome MCP P1-c roundtrip dev 검증 용도만. 콘솔에 "persistence 미구현 — P3-D 후 commit 가능" 안내 출력.

PR-E2 skip 결정: usePresetApply.ts read 는 이미 selectCanonicalDocument 사용 (dual-mode 친화적). write 는 P3-D canonical document write API 의존 — Phase 2 cutover 에 필수 아님. 별도 ADR 로 처리.

Why: ADR-911 Phase 1 의 migration helper (hoistLayoutAsReusableFrame / dryRun / apply) 가 실 dev 데이터에 대해 정상 동작하는지 검증할 진입점
부재. P2-e Chrome MCP P1-c roundtrip 옵션 A (FramesTab dev menu) 채택. P3 진입 시 옵션 B (initializeProject 자동 trigger) 로 교체 예정.

검증: type-check 0 / FramesTab 33/33 회귀 0 / migrationP911 45/45 회귀 0 / db 전체 126/126 회귀 0.