### PR TITLE
feat(adr-911-p2-e4)!: Phase 2 cutover — canonical mode default true 전환

### DIFF
--- a/apps/builder/src/utils/featureFlags.ts
+++ b/apps/builder/src/utils/featureFlags.ts
@@ -157,15 +157,20 @@ export function isReactQueryDevtoolsEnabled(): boolean {
  *
  * `true` 일 때 FramesTab 의 frame 목록 read 가 `selectCanonicalDocument` 기반
  * canonical projection 으로 동작. `false` 일 때 legacy `useLayoutsStore.layouts[]`
- * direct read 유지 (PR-A baseline 보호).
+ * direct read 유지.
  *
- * 기본값 `false` — PR-B (FramesTab read path 전환) 진입 시 dual-mode 운영 후
- * 1주 issue 0 확인 시 true 로 전환 (P2-d).
+ * **PR-E4 (2026-04-27) cutover**: 기본값 `false` → `true` 전환.
+ * - PR-A~E3 (8 PRs main land) + 33/33 vitest 회귀 안전망 + dev migration trigger
+ *   (P1-c roundtrip 검증 가능) 토대 위에서 cutover 진행
+ * - 사용자 환경변수 override 가능 (`VITE_FRAMES_TAB_CANONICAL=false`) — emergency
+ *   rollback 경로 보장
+ * - 1주 모니터링 (사용자 issue report 0건 확인) 후 ADR-911 Phase 2 Status:
+ *   `In Progress` → `Phase 2 Implemented` 승격
  *
- * @returns true if FramesTab canonical-native read 활성화
+ * @returns true if FramesTab canonical-native read 활성화 (default true)
  */
 export function isFramesTabCanonical(): boolean {
-  return parseBoolean(import.meta.env.VITE_FRAMES_TAB_CANONICAL, false);
+  return parseBoolean(import.meta.env.VITE_FRAMES_TAB_CANONICAL, true);
 }
 
 /**
@@ -193,7 +198,7 @@ export function getFeatureFlags(): FeatureFlags {
     ),
     framesTabCanonical: parseBoolean(
       import.meta.env.VITE_FRAMES_TAB_CANONICAL,
-      false,
+      true,
     ),
   };
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ADR-911 Phase 2 PR-E4 — cutover (canonical mode default true) — 세션 37 후반] - 2026-04-27
+
+### Breaking Changes
+
+- **FramesTab + PageLayoutSelector 의 frame 목록 read path 가 canonical projection 으로 default 전환** (ADR-911 Phase 2 cutover):
+  - `apps/builder/src/utils/featureFlags.ts::isFramesTabCanonical()` default `false → true`
+  - 영향: 빌더 `Frames` 탭 / `PageLayoutSelector` 가 `selectCanonicalDocument` projection 의 reusable FrameNode 를 read source 로 사용. 기존 `useLayoutsStore.layouts[]` direct read 는 환경변수 override 시에만 활성화
+  - **rollback 경로**: `VITE_FRAMES_TAB_CANONICAL=false` 환경변수 설정 → emergency 시 legacy path 복구
+  - **사용자 가시 차이**: frame 목록 표시 source 가 canonical document 의 `reusable: true` FrameNode 로 통일 (id 정규화 `metadata.layoutId` 경유). write 경로는 legacy `createLayout`/`deleteLayout`/`pages.update(layout_id)` 그대로 — 데이터 손실 위험 없음
+  - **Why**: PR-A~E3 (8 PRs main land + 156 vitest 회귀 안전망 + dev migration trigger) 토대 위에서 cutover 진행. P3-D (canonical document write API) 진입 전 read 정합화 완료로 향후 cascade 재작성 시 read path 변경 0
+
+### Architecture
+
+- **ADR-911 Phase 2 PR-E4 — cutover 단일 변경**:
+  - `featureFlags.ts` 의 `isFramesTabCanonical()` 1줄 변경 (default `false → true`) + `getFeatureFlags()` 동시 갱신
+  - vitest 영향 0 — `FramesTab.test.tsx` / `PageLayoutSelector` 등 모두 `mockIsFramesTabCanonical` 명시 mock 으로 분기 검증
+  - 검증: type-check 0 / 156/156 vitest PASS (FramesTab 33 + frameActions 7 + migrationP911 45 + canonical adapters 71)
+  - **monitoring 단계**: 1주 사용자 issue report 0건 확인 후 ADR-911 Phase 2 Status: `In Progress` → `Phase 2 Implemented` 승격. 잔여 Phase 3-5 (P3 cascade 재작성 / P4 DB schema migration / P5 hybrid 6 cleanup) 는 본 ADR 의 후속 phase 로 분리 진행
+
 ## [ADR-911 Phase 2 PR-E3 — dev-only canonical migration trigger — 세션 37 후반] - 2026-04-27
 
 ### Features

--- a/docs/adr/911-layout-frameset-pencil-redesign.md
+++ b/docs/adr/911-layout-frameset-pencil-redesign.md
@@ -55,7 +55,13 @@ In Progress — 2026-04-26 → 2026-04-27
   - production 단락: `process.env.NODE_ENV === "development"` 체크. production build 영향 0
   - **persistence 미구현**: canonical document store write API 가 없음 (P3-D 종속). Chrome MCP P1-c roundtrip dev 검증 용도만
   - 검증: type-check 0 / FramesTab 33/33 회귀 0 / migrationP911 45/45 회귀 0 / db 전체 126/126 회귀 0
-- **잔여 Phase 2 sub-PR**: PR-E4 (1주 dual-mode + cutover, `VITE_FRAMES_TAB_CANONICAL=true` default 전환)
+- **2026-04-27 (세션 37 후속)**: **PR-E4: Phase 2 cutover — flag default true 전환** (PR pending)
+  - `featureFlags.ts` `isFramesTabCanonical()` default `false → true`. `getFeatureFlags()` 내부 default 도 동시 갱신
+  - 사용자 환경변수 override 가능 (`VITE_FRAMES_TAB_CANONICAL=false`) — emergency rollback 경로 보장
+  - **canonical mode** 가 production default 가 됨 — FramesTab + PageLayoutSelector 모두 `selectCanonicalDocument` projection 으로 read
+  - 검증: type-check 0 / 156/156 vitest PASS (FramesTab 33 + frameActions 7 + migrationP911 45 + canonical adapters 71) — vitest 는 mockState 격리로 default 변경 영향 0
+  - **1주 모니터링** (사용자 issue report 0건 확인) 후 본 ADR Status: `In Progress` → `Phase 2 Implemented` 승격
+- **Phase 2 cutover 완료** — read path canonical 전환 + 컴포넌트 분리 + dev migration trigger + 모니터링 진입. 잔여 영역 (P3 cascade 재작성, P4 DB schema migration, P5 hybrid 6 cleanup) 은 본 ADR 의 Phase 3-5 로 분리 진행
 
 ## Context
 

--- a/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
+++ b/docs/adr/design/911-layout-frameset-pencil-redesign-breakdown.md
@@ -450,7 +450,7 @@ const handleDevMigrate = useCallback(async () => {
 | **E1** | `PageLayoutSelector` dual-mode read 전환 + `slotAndLayoutAdapter` description 보존                     | P2-c 부분        | ✅ 2026-04-27 (PR pending)           |
 | **E2** | `usePresetApply.ts` canonical mutation 전환 (write 경로 P3-D 종속 — defer)                             | P2-c 잔여        | 🔄 P3-D 종속 — 별도 ADR 로 처리      |
 | **E3** | dev migration trigger (handleDevMigrate) + Chrome MCP P1-c roundtrip                                   | P2-e             | ✅ 2026-04-27 (PR pending)           |
-| **E4** | 1주 dual-mode + cutover (`VITE_FRAMES_TAB_CANONICAL=true` default 전환)                                | P2-f + P2-g      | 후속 세션                            |
+| **E4** | cutover (`VITE_FRAMES_TAB_CANONICAL=true` default 전환) — 1주 모니터링 진입                            | P2-f + P2-g      | ✅ 2026-04-27 (PR pending)           |
 | **G**  | parallel-verify 25/25 + 1주 dual-mode + cutover                                                        | P2-f + P2-g      | 후속 세션                            |
 
 | Step       | 내용                                                                                                                      | 시간 | RED/GREEN 사이클                                                                                     |


### PR DESCRIPTION
BREAKING CHANGE: FramesTab + PageLayoutSelector 의 frame 목록 read path 가 canonical projection 으로 default 전환.

featureFlags.ts::isFramesTabCanonical() default false → true. getFeatureFlags() 내부 default 도 동시 갱신.

영향: 빌더 Frames 탭 / PageLayoutSelector 가 selectCanonicalDocument projection 의 reusable FrameNode 를 read source 로 사용. id 정규화 metadata.layoutId 경유로 legacy CRUD 와 정합 유지.

rollback 경로: VITE_FRAMES_TAB_CANONICAL=false 환경변수 설정 → emergency 시 legacy path 복구.

write 경로는 legacy 그대로 — createLayout/deleteLayout/pages.update 호출. 데이터 손실 위험 없음.

Why: PR-A~E3 (8 PRs main land + 156 vitest 회귀 안전망 + dev migration trigger P1-c roundtrip 검증 가능) 토대 위에서 cutover. P3-D (canonical document write API) 진입 전 read 정합화 완료로 향후 cascade 재작성 시 read path 변경 0.

Monitoring: 1주 사용자 issue report 0건 확인 후 ADR-911 Phase 2 Status: In Progress → Phase 2 Implemented 승격.

검증: type-check 0 / 156/156 vitest PASS (FramesTab 33 + frameActions 7 + migrationP911 45 + canonical adapters 71). vitest 는 mockState 격리로 default 변경 영향 0.