### PR TITLE
docs(adr-911-p2-followup): NodesPanelTabs UI 라벨 "Layout" → "Frames"

### DIFF
--- a/apps/builder/src/builder/panels/nodes/NodesPanelTabs.tsx
+++ b/apps/builder/src/builder/panels/nodes/NodesPanelTabs.tsx
@@ -20,7 +20,11 @@ export function NodesPanelTabs({
   activeTab,
   onTabChange,
 }: NodesPanelTabsProps) {
-  const tabs: { id: NodesPanelTabType; label: string; icon: React.ReactNode }[] = [
+  const tabs: {
+    id: NodesPanelTabType;
+    label: string;
+    icon: React.ReactNode;
+  }[] = [
     {
       id: "pages",
       label: "Page",
@@ -33,8 +37,10 @@ export function NodesPanelTabs({
       ),
     },
     {
+      // ADR-911 P2 followup: UI 라벨만 "Frames" — 탭 id "layouts" / EditMode "layout"
+      // 은 데이터 호환성 유지를 위해 그대로. 후속 PR 에서 정합화 가능.
       id: "layouts",
-      label: "Layout",
+      label: "Frames",
       icon: (
         <Layout
           color={iconProps.color}
@@ -46,7 +52,11 @@ export function NodesPanelTabs({
   ];
 
   return (
-    <div className="nodes-panel-tabs" role="tablist" aria-label="Nodes Panel Tabs">
+    <div
+      className="nodes-panel-tabs"
+      role="tablist"
+      aria-label="Nodes Panel Tabs"
+    >
       {tabs.map((tab) => (
         <button
           key={tab.id}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ADR-911 Phase 2 followup — NodesPanelTabs UI 라벨 "Layout" → "Frames" — 세션 38] - 2026-04-27
+
+### Documentation
+
+- **NodesPanel 탭 UI 라벨 정합**:
+  - `NodesPanelTabs.tsx` — `id: "layouts"` 의 `label: "Layout"` → `"Frames"` (1줄)
+  - **Why**: 컴포넌트명 `FramesTab` 과 UI 라벨 "Layout" 의 불일치로 사용자 dev 검증 시 혼란 — ADR-911 Phase 2 cutover 와 함께 라벨 정합. 탭 id `"layouts"` / `EditMode "layout"` / `aria-controls "tabpanel-layouts"` 등 데이터 호환성 식별자는 그대로 유지 (후속 PR 에서 점진 정리 가능)
+  - 검증: type-check 0 / FramesTab 33/33 회귀 0 (라벨은 vitest 검증 대상 아님 — UI 가시 변경만)
+
 ## [ADR-911 Phase 2 PR-E4 — cutover (canonical mode default true) — 세션 37 후반] - 2026-04-27
 
 ### Breaking Changes


### PR DESCRIPTION
컴포넌트명 FramesTab 과 UI 라벨 "Layout" 불일치로 사용자 dev 검증 시 혼란 → 라벨 정합 (1줄 변경).

탭 id "layouts" / EditMode "layout" / aria-controls "tabpanel-layouts" 등 데이터 호환성 식별자는 그대로 유지 — 후속 PR 에서 점진 정리 가능.

Why: ADR-911 Phase 2 cutover (PR-E4) 직후 dev 검증 진입 시 사용자 혼란 해소. 데이터 모델 변경 0, UI 가시 변경만.

검증: type-check 0 / FramesTab 33/33 회귀 0.