### PR TITLE
fix(adr-911): handleAddFrame 중복 Frame N 번호 회피 (사용자 dev 검증 발견)

### DIFF
--- a/apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx
+++ b/apps/builder/src/builder/panels/nodes/FramesTab/FramesTab.tsx
@@ -25,6 +25,7 @@ import {
   createReusableFrame,
   deleteReusableFrame,
   selectReusableFrame,
+  getNextFrameName,
 } from "../../../stores/utils/frameActions";
 import { useEditModeStore } from "../../../stores/editMode";
 import { useStore } from "../../../stores";
@@ -271,7 +272,10 @@ export function FramesTab({
     [reusableFrames, handleSelectFrame, setEditModeLayoutId],
   );
 
-  // 새 Frame 생성 핸들러 — frameActions.createReusableFrame 위임
+  // 새 Frame 생성 핸들러 — frameActions.createReusableFrame 위임.
+  // unique 한 default 이름은 getNextFrameName 으로 안정 생성 — 이전 패턴
+  // (`Frame ${reusableFrames.length + 1}`) 의 중복 위험 제거 (delete 후 add 또는
+  // IDB 잔존 데이터 + 메모리 length mismatch 시 충돌 방지).
   const handleAddFrame = useCallback(async () => {
     if (!projectId) {
       console.error("[FramesTab] 프로젝트 ID가 없습니다");
@@ -279,14 +283,14 @@ export function FramesTab({
     }
     try {
       const ref = await createReusableFrame({
-        name: `Frame ${reusableFrames.length + 1}`,
+        name: getNextFrameName(reusableFrames),
         projectId,
       });
       handleSelectFrame(ref.id);
     } catch (error) {
       console.error("[FramesTab] Frame 생성 에러:", error);
     }
-  }, [projectId, reusableFrames.length, handleSelectFrame]);
+  }, [projectId, reusableFrames, handleSelectFrame]);
 
   // Element 삭제 핸들러
   const handleDeleteElement = useCallback(

--- a/apps/builder/src/builder/panels/nodes/FramesTab/__tests__/FramesTab.test.tsx
+++ b/apps/builder/src/builder/panels/nodes/FramesTab/__tests__/FramesTab.test.tsx
@@ -62,6 +62,17 @@ vi.mock("@/builder/stores/utils/frameActions", () => ({
   createReusableFrame: vi.fn(),
   deleteReusableFrame: vi.fn(),
   selectReusableFrame: vi.fn(),
+  // 실제 로직 흉내 — Frame N 패턴 추출 + 미사용 번호 사용
+  getNextFrameName: (frames: ReadonlyArray<{ name: string }>) => {
+    const used = new Set<number>();
+    for (const f of frames) {
+      const m = /^Frame (\d+)$/.exec(f.name);
+      if (m) used.add(Number(m[1]));
+    }
+    let n = 1;
+    while (used.has(n)) n++;
+    return `Frame ${n}`;
+  },
 }));
 
 vi.mock("@/builder/stores/editMode", () => ({
@@ -203,9 +214,9 @@ describe("FramesTab (ADR-911 P2-a PR-B baseline)", () => {
       await Promise.resolve();
 
       expect(createReusableFrameMock).toHaveBeenCalledTimes(1);
-      // 기존 1개 frame 있으므로 새 frame 이름은 "Frame 2" (layouts.length + 1)
+      // 기존 frame "Existing" 은 Frame N 패턴 아님 → getNextFrameName 이 "Frame 1" 반환
       expect(createReusableFrameMock).toHaveBeenCalledWith({
-        name: "Frame 2",
+        name: "Frame 1",
         projectId: "test-project",
       });
     });

--- a/apps/builder/src/builder/stores/utils/__tests__/frameActions.test.ts
+++ b/apps/builder/src/builder/stores/utils/__tests__/frameActions.test.ts
@@ -21,6 +21,7 @@ import {
   deleteReusableFrame,
   updateReusableFrameName,
   selectReusableFrame,
+  getNextFrameName,
 } from "../frameActions";
 import type { Layout } from "@/types/builder/layout.types";
 
@@ -149,6 +150,56 @@ describe("frameActions (ADR-911 P2-a)", () => {
       selectReusableFrame(null);
 
       expect(setCurrentLayoutSpy).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("getNextFrameName (중복 회피)", () => {
+    it("빈 배열 → 'Frame 1'", () => {
+      expect(getNextFrameName([])).toBe("Frame 1");
+    });
+
+    it("['Frame 1', 'Frame 2'] → 'Frame 3' (max + 1)", () => {
+      expect(getNextFrameName([{ name: "Frame 1" }, { name: "Frame 2" }])).toBe(
+        "Frame 3",
+      );
+    });
+
+    it("['Frame 1', 'Frame 3'] → 'Frame 2' (gap 채움)", () => {
+      expect(getNextFrameName([{ name: "Frame 1" }, { name: "Frame 3" }])).toBe(
+        "Frame 2",
+      );
+    });
+
+    it("['Frame 2'] → 'Frame 1' (시작 gap 채움)", () => {
+      expect(getNextFrameName([{ name: "Frame 2" }])).toBe("Frame 1");
+    });
+
+    it("['My Custom'] → 'Frame 1' (Frame N 패턴 아닌 이름은 무시)", () => {
+      expect(getNextFrameName([{ name: "My Custom" }])).toBe("Frame 1");
+    });
+
+    it("['Frame 1', 'My Custom', 'Frame 3'] → 'Frame 2'", () => {
+      expect(
+        getNextFrameName([
+          { name: "Frame 1" },
+          { name: "My Custom" },
+          { name: "Frame 3" },
+        ]),
+      ).toBe("Frame 2");
+    });
+
+    it("이전 length+1 패턴이 만들 수 있는 충돌 시나리오 회피 — 삭제 후 추가", () => {
+      // 시나리오: 3개 생성 → Frame 1 삭제 → 추가 → 이전에는 'Frame 3' 충돌
+      const afterDelete = [{ name: "Frame 2" }, { name: "Frame 3" }];
+      // length+1 = 3 → 충돌. getNextFrameName 은 'Frame 1' 반환 (gap 채움)
+      expect(getNextFrameName(afterDelete)).toBe("Frame 1");
+    });
+
+    it("100 개 frame 까지 안정적 (numeric overflow 안 함)", () => {
+      const frames = Array.from({ length: 100 }, (_, i) => ({
+        name: `Frame ${i + 1}`,
+      }));
+      expect(getNextFrameName(frames)).toBe("Frame 101");
     });
   });
 });

--- a/apps/builder/src/builder/stores/utils/frameActions.ts
+++ b/apps/builder/src/builder/stores/utils/frameActions.ts
@@ -107,3 +107,39 @@ export async function updateReusableFrameName(
 export function selectReusableFrame(frameId: string | null): void {
   useLayoutsStore.getState().setCurrentLayout(frameId);
 }
+
+/**
+ * 새 reusable frame 의 unique 한 default 이름 생성.
+ *
+ * `Frame N` 패턴의 기존 이름들을 분석하여 미사용 번호 중 가장 작은 값 사용.
+ * 이전 패턴 (`Frame ${frames.length + 1}`) 의 중복 위험 제거 — frame 삭제 후
+ * 추가하거나 IDB 잔존 데이터 + 메모리 length mismatch 시 발생하는 충돌 방지.
+ *
+ * 동작:
+ * - 빈 목록: `Frame 1`
+ * - `["Frame 1", "Frame 2"]`: `Frame 3`
+ * - `["Frame 1", "Frame 3"]`: `Frame 2` (gap 채움)
+ * - `["Frame 2"]`: `Frame 1` (시작 gap 채움)
+ * - `["My Custom"]`: `Frame 1` (`Frame N` 패턴 아닌 이름은 무시)
+ * - `["Frame 1", "My Custom", "Frame 3"]`: `Frame 2`
+ *
+ * @param existingFrames - 현재 frame 목록 (id 와 name 만 사용)
+ * @returns 새 frame 의 default 이름 (예: `Frame 4`)
+ */
+export function getNextFrameName(
+  existingFrames: ReadonlyArray<{ name: string }>,
+): string {
+  const usedNumbers = new Set<number>();
+  const pattern = /^Frame (\d+)$/;
+  for (const frame of existingFrames) {
+    const match = pattern.exec(frame.name);
+    if (match) {
+      usedNumbers.add(Number(match[1]));
+    }
+  }
+  let n = 1;
+  while (usedNumbers.has(n)) {
+    n++;
+  }
+  return `Frame ${n}`;
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ADR-911 Phase 2 fix — handleAddFrame 중복 Frame N 번호 회피 — 세션 38] - 2026-04-27
+
+### Bug Fixes
+
+- **Frame 추가 시 중복 `Frame N` 번호 생성 회귀 수정** (사용자 dev 검증으로 발견):
+  - 증상: 여러 Frame 추가 후 일부 삭제 + 재추가 시 같은 번호 (`Frame 2` 등) 가 중복 생성됨
+  - **Why**: 이전 패턴 `Frame ${reusableFrames.length + 1}` 은 stable unique 보장 안 함. `[Frame 1, Frame 2, Frame 3]` → Frame 1 삭제 → `[Frame 2, Frame 3]` (length=2) → 추가 → `Frame 3` 생성 → 충돌
+  - 수정: `getNextFrameName(existingFrames)` helper 도입. `Frame N` 패턴의 기존 이름들을 분석하여 미사용 번호 중 가장 작은 값 사용 (gap 채움 + 시작 gap 채움 + 비-`Frame N` 이름 무시)
+  - 위치: `apps/builder/src/builder/stores/utils/frameActions.ts` (`getNextFrameName` export) + `FramesTab.tsx::handleAddFrame` 적용
+  - vitest 8 신규 시나리오: 빈 / max+1 / mid gap / 시작 gap / 비-Frame 이름 무시 / mixed / delete-after-add 회귀 / 100개 stable
+
+### Documentation
+
+- **frameActions.test.ts 회귀 안전망 강화**: 기존 7 → 15 시나리오. PR-A wrapper 동작 + `getNextFrameName` 알고리즘 양쪽 잠금
+
 ## [ADR-911 Phase 2 followup — NodesPanelTabs UI 라벨 "Layout" → "Frames" — 세션 38] - 2026-04-27
 
 ### Documentation


### PR DESCRIPTION
증상: 여러 Frame 추가 후 일부 삭제 + 재추가 시 같은 번호 중복 생성.

Root cause: Frame ${reusableFrames.length + 1} 패턴이 stable unique 보장 안 함. [Frame 1, Frame 2, Frame 3] → Frame 1 삭제 → length=2 → 추가 → "Frame 3" 생성 → 충돌.

Fix: getNextFrameName(existingFrames) helper — Frame N 패턴 기존 이름 분석 + 미사용 번호 중 가장 작은 값 사용. gap 채움 + 시작 gap 채움 +
비-Frame N 이름 무시.

vitest 8 신규 (frameActions.test.ts: 7 → 15 시나리오):
- 빈 / max+1 / mid gap / 시작 gap / 비-Frame 이름 무시 / mixed / delete-after-add 회귀 / 100개 stable
- FramesTab.test.tsx Add 시나리오 expected 갱신: existingFrames=[Existing] (Frame N 아님) → "Frame 1" (이전 "Frame 2")

검증: type-check 0 / 41/41 vitest PASS (frameActions 15 + FrameList 6 + FrameElementTree 12 + FramesTab 8).