### PR TITLE
diag(adr-911): preset stale 진단 console.log 추가 (dev only)

### DIFF
--- a/apps/builder/src/builder/panels/properties/editors/LayoutBodyEditor.tsx
+++ b/apps/builder/src/builder/panels/properties/editors/LayoutBodyEditor.tsx
@@ -32,6 +32,15 @@ export const LayoutBodyEditor = memo(
     // ⭐ 최적화: customId와 layoutId를 현재 시점에만 가져오기 (Zustand 구독 방지)
     const { customId, layoutId } = useMemo(() => {
       const element = useStore.getState().elementsMap.get(elementId);
+      // [ADR-911 diag] preset stale 진단 — frame 교차 시 useMemo 재계산 + layoutId 갱신 추적
+      if (import.meta.env.DEV) {
+        console.log("[ADR-911 diag][LayoutBodyEditor]", {
+          elementId,
+          layoutId: element?.layout_id,
+          appliedPreset: (element?.props as { appliedPreset?: string })
+            ?.appliedPreset,
+        });
+      }
       return {
         customId: element?.customId || "",
         layoutId: element?.layout_id || null,

--- a/apps/builder/src/builder/panels/properties/editors/LayoutPresetSelector/index.tsx
+++ b/apps/builder/src/builder/panels/properties/editors/LayoutPresetSelector/index.tsx
@@ -60,6 +60,17 @@ export const LayoutPresetSelector = memo(function LayoutPresetSelector({
       bodyElementId,
     });
 
+  // [ADR-911 diag] preset stale 진단 — render 시 props + currentPresetKey 추적
+  if (import.meta.env.DEV) {
+    console.log("[ADR-911 diag][LayoutPresetSelector] render", {
+      layoutId,
+      bodyElementId,
+      currentPresetKey,
+      selectedPresetKey,
+      existingSlotsCount: existingSlots.length,
+    });
+  }
+
   // 카테고리별 프리셋 그룹화
   const presetsByCategory = useMemo(() => {
     const groups: Record<string, string[]> = {

--- a/apps/builder/src/builder/panels/properties/editors/LayoutPresetSelector/usePresetApply.ts
+++ b/apps/builder/src/builder/panels/properties/editors/LayoutPresetSelector/usePresetApply.ts
@@ -102,7 +102,15 @@ export function usePresetApply({
   const currentPresetKey = useMemo((): string | null => {
     // ADR-040: elementsMap O(1) 조회
     const body = elementsMap.get(bodyElementId);
-    if (!body) return null;
+    if (!body) {
+      if (import.meta.env.DEV) {
+        console.log(
+          "[ADR-911 diag][usePresetApply] body 없음 — bodyElementId:",
+          bodyElementId,
+        );
+      }
+      return null;
+    }
 
     const appliedPreset = (body.props as { appliedPreset?: string })
       ?.appliedPreset;
@@ -118,12 +126,39 @@ export function usePresetApply({
         existingSlotNames.size === presetSlotNames.size &&
         [...existingSlotNames].every((name) => presetSlotNames.has(name))
       ) {
+        if (import.meta.env.DEV) {
+          console.log("[ADR-911 diag][usePresetApply] currentPresetKey =", {
+            bodyElementId,
+            layoutId,
+            appliedPreset,
+            existingSlotNames: [...existingSlotNames],
+            presetSlotNames: [...presetSlotNames],
+            match: true,
+          });
+        }
         return appliedPreset;
       }
+
+      if (import.meta.env.DEV) {
+        console.log("[ADR-911 diag][usePresetApply] slot mismatch:", {
+          bodyElementId,
+          layoutId,
+          appliedPreset,
+          existingSlotNames: [...existingSlotNames],
+          presetSlotNames: [...presetSlotNames],
+        });
+      }
+    } else if (import.meta.env.DEV) {
+      console.log(
+        "[ADR-911 diag][usePresetApply] appliedPreset 없음/unknown — bodyElementId:",
+        bodyElementId,
+        "appliedPreset:",
+        appliedPreset,
+      );
     }
 
     return null;
-  }, [elementsMap, bodyElementId, existingSlots]);
+  }, [elementsMap, bodyElementId, existingSlots, layoutId]);
 
   // 프리셋 적용 함수
   const applyPreset = useCallback(


### PR DESCRIPTION
이슈: Frame 교차 시 우측 LayoutPresetSelector 의 "적용됨" 표시가 stale. 좌측 Layers 는 정상 갱신 (selectedElementId 변경 OK), 우측만 react 안 함.

코드 흐름 분석상 정상이어야 하는데 stale → 어디서 react 누락인지 확정
필요. Phase 1 Root Cause Investigation 단계 — Phase 4 fix 전 진단 의무.

진단 console.log 3곳 추가 (process.env.NODE_ENV !== "development" 단락):
- LayoutBodyEditor useMemo([elementId]): 재계산 시 elementId/layoutId/ appliedPreset 출력
- usePresetApply currentPresetKey useMemo: bodyElementId/layoutId/ appliedPreset/existingSlotNames/match 출력. layoutId 도 deps 추가
- LayoutPresetSelector render: layoutId/bodyElementId/currentPresetKey/ existingSlotsCount 출력

dev 환경에서 frame 교차 후 콘솔 출력 패턴으로 root cause 확정 후 Phase 4 real fix 진입. 본 PR 은 진단 후 revert.