### PR TITLE
fix(adr-911): usePresetApply.existingSlots slot 직접 매칭 (preset stale 해소)

### DIFF
--- a/apps/builder/src/builder/panels/properties/editors/LayoutPresetSelector/usePresetApply.ts
+++ b/apps/builder/src/builder/panels/properties/editors/LayoutPresetSelector/usePresetApply.ts
@@ -12,9 +12,6 @@
 
 import { useCallback, useMemo, useState } from "react";
 import { useStore } from "../../../../stores";
-import { selectCanonicalDocument } from "../../../../stores/elements";
-import { useLayoutsStore } from "../../../../stores/layouts";
-import { belongsToLegacyLayout } from "../../../../../adapters/canonical";
 import { LAYOUT_PRESETS } from "./presetDefinitions";
 import type {
   PresetApplyMode,
@@ -58,23 +55,22 @@ export function usePresetApply({
   const removeElement = useStore((state) => state.removeElement);
   const updateElementProps = useStore((state) => state.updateElementProps);
 
-  // 현재 Layout의 기존 Slot 목록 (canonical reusable frame descendants + type === "Slot")
-  // ADR-903 P3-E E-6 후속: layout slot 검색에 canonical document 필요
-  // (write-through 후 element.layout_id null → frame descendants 매칭).
-  // doc 을 useStore selector 로 구독하지 않고 useMemo 안에서 lazy 생성 —
-  // selectCanonicalDocument 가 매 호출마다 새 객체를 반환하면 useSyncExternalStore
-  // cache miss 로 무한 루프 (Maximum update depth) 발생.
+  // 현재 Layout의 기존 Slot 목록.
+  //
+  // ADR-911 P2 fix: 이전 구현은 `belongsToLegacyLayout(el, layoutId, canonicalDoc)`
+  // 로 canonical document 기반 매칭. 그러나 `convertLayoutToReusableFrame` 가
+  // slot element 를 `convertElementWithSlotHoisting` 으로 hoist 하여 canonical
+  // frame.children 에 slot 이 사라짐 → `isCanonicalDescendantOf(slot, frame)`
+  // 항상 false → existingSlots 0개 → currentPresetKey null → 우측 LayoutPresetSelector
+  // 의 "적용됨" 표시 stale.
+  //
+  // 직접 매칭 (`el.layout_id === layoutId`) 은 hoist 영향 받지 않음. slot 은
+  // P4 까지 legacy element 로 elementsMap 에 존재 (layout_id field 보유). 좌측
+  // FramesTab.frameElements 도 같은 직접 매칭 패턴 사용 — 정상 작동 확인됨.
   const existingSlots = useMemo((): ExistingSlotInfo[] => {
-    const state = useStore.getState();
-    const layouts = useLayoutsStore.getState().layouts;
-    const canonicalDoc = selectCanonicalDocument(state, state.pages, layouts);
-
     const slots: ExistingSlotInfo[] = [];
     elementsMap.forEach((el) => {
-      if (
-        el.type === "Slot" &&
-        belongsToLegacyLayout(el, layoutId, canonicalDoc)
-      ) {
+      if (el.type === "Slot" && el.layout_id === layoutId) {
         const slotChildren = childrenMap.get(el.id) ?? [];
         const slotName =
           ((el.props as { name?: string })?.name as string) || "unnamed";

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ADR-911 fix — usePresetApply.existingSlots slot 직접 매칭 (preset stale 해소) — 세션 38] - 2026-04-27
+
+### Bug Fixes
+
+- **Frame 교차 시 우측 LayoutPresetSelector "적용됨" 표시 stale 회귀 수정** (사용자 dev 검증 + 진단 console.log 로 root cause 확정):
+  - 증상: Frame A 에 preset X 적용 → 우측 selector 에 "X 적용됨" 표시 정상. Frame B 로 교차 → 좌측 Layers 는 정상 갱신되지만 우측 selector 의 "적용됨" 표시는 **항상 null** 로 갱신됨 (Frame B 에 적용된 preset 표시 안 됨)
+  - **Root cause** (Phase 1 진단 로그):
+    ```
+    [usePresetApply] slot mismatch: {
+      bodyElementId: B_body, layoutId: B,
+      appliedPreset: 'sidebar-left',  // body 에 정상 저장
+      existingSlotNames: Array(0),    // ← 0개! Slot 매칭 실패
+      presetSlotNames: Array(2)       // preset 정의는 2 slots
+    }
+    ```
+  - 분석: `existingSlots` 가 `belongsToLegacyLayout(el, layoutId, canonicalDoc)` 로 매칭. 이 helper 는 `isCanonicalDescendantOf(slot.id, frame)` 로 canonical document 의 frame 자식 트리 검색. 그러나 `convertLayoutToReusableFrame` (slotAndLayoutAdapter.ts) 가 slot element 를 `convertElementWithSlotHoisting` 으로 frame.slot 메타로 hoist → canonical frame.children 에 slot 사라짐 → `isCanonicalDescendantOf` 항상 false → existingSlots = []
+  - 좌측 Layers 가 정상인 이유: `FramesTab.frameElements` 는 `el.layout_id === currentFrame.id` 직접 매칭, canonical 미사용
+  - 수정: `usePresetApply.existingSlots` 가 `belongsToLegacyLayout` 호출 제거 + slot 을 `el.layout_id === layoutId` 직접 매칭. slot 은 P4 까지 legacy element 로 elementsMap 에 존재 (layout_id field 보유) → safe. import 정리: `selectCanonicalDocument` / `useLayoutsStore` / `belongsToLegacyLayout` 제거
+  - 위치: `apps/builder/src/builder/panels/properties/editors/LayoutPresetSelector/usePresetApply.ts`
+  - 검증: type-check 0 / FramesTab+frameActions 41/41 회귀 0. dev 환경에서 Frame 교차 시 우측 "적용됨" 표시가 frame 의 실제 preset 으로 정상 갱신 (사용자 검증 권장)
+
 ## [ADR-911 Phase 2 fix — handleAddFrame 중복 Frame N 번호 회피 — 세션 38] - 2026-04-27
 
 ### Bug Fixes


### PR DESCRIPTION
Frame 교차 시 우측 LayoutPresetSelector "적용됨" 표시가 항상 null 인 회귀 수정.

Root cause (진단 로그로 확정):
existingSlots 가 belongsToLegacyLayout(el, layoutId, canonicalDoc) 로 매칭. 이 helper 는 isCanonicalDescendantOf(slot.id, frame) 로 canonical frame.children 검색. 그러나 convertLayoutToReusableFrame 가 slot element 를 convertElementWithSlotHoisting 으로 frame.slot 메타로 hoist → canonical frame.children 에 slot 사라짐 → existingSlots = [] → slot count mismatch → currentPresetKey null.

좌측 Layers 가 정상인 이유: frameElements 는 el.layout_id === frame.id 직접 매칭 (canonical 미사용).

Fix: existingSlots 가 belongsToLegacyLayout 호출 제거 + slot 을 el.layout_id === layoutId 직접 매칭. slot 은 P4 까지 legacy element 로 elementsMap 에 존재 (layout_id field 보유) → safe. import 정리: selectCanonicalDocument / useLayoutsStore / belongsToLegacyLayout 제거.

검증: type-check 0 / FramesTab+frameActions 41/41 회귀 0. dev 환경에서 Frame 교차 시 우측 "적용됨" 표시가 frame 의 실제 preset 으로 정상 갱신 (사용자 검증 권장).