### PR TITLE
chore(adr-911): preset stale 진단 console.log 제거 — Phase 2 monitoring 후…

### DIFF
--- a/apps/builder/src/builder/panels/properties/editors/LayoutBodyEditor.tsx
+++ b/apps/builder/src/builder/panels/properties/editors/LayoutBodyEditor.tsx
@@ -32,15 +32,6 @@ export const LayoutBodyEditor = memo(
     // ⭐ 최적화: customId와 layoutId를 현재 시점에만 가져오기 (Zustand 구독 방지)
     const { customId, layoutId } = useMemo(() => {
       const element = useStore.getState().elementsMap.get(elementId);
-      // [ADR-911 diag] preset stale 진단 — frame 교차 시 useMemo 재계산 + layoutId 갱신 추적
-      if (import.meta.env.DEV) {
-        console.log("[ADR-911 diag][LayoutBodyEditor]", {
-          elementId,
-          layoutId: element?.layout_id,
-          appliedPreset: (element?.props as { appliedPreset?: string })
-            ?.appliedPreset,
-        });
-      }
       return {
         customId: element?.customId || "",
         layoutId: element?.layout_id || null,

--- a/apps/builder/src/builder/panels/properties/editors/LayoutPresetSelector/index.tsx
+++ b/apps/builder/src/builder/panels/properties/editors/LayoutPresetSelector/index.tsx
@@ -60,17 +60,6 @@ export const LayoutPresetSelector = memo(function LayoutPresetSelector({
       bodyElementId,
     });
 
-  // [ADR-911 diag] preset stale 진단 — render 시 props + currentPresetKey 추적
-  if (import.meta.env.DEV) {
-    console.log("[ADR-911 diag][LayoutPresetSelector] render", {
-      layoutId,
-      bodyElementId,
-      currentPresetKey,
-      selectedPresetKey,
-      existingSlotsCount: existingSlots.length,
-    });
-  }
-
   // 카테고리별 프리셋 그룹화
   const presetsByCategory = useMemo(() => {
     const groups: Record<string, string[]> = {

--- a/apps/builder/src/builder/panels/properties/editors/LayoutPresetSelector/usePresetApply.ts
+++ b/apps/builder/src/builder/panels/properties/editors/LayoutPresetSelector/usePresetApply.ts
@@ -98,15 +98,7 @@ export function usePresetApply({
   const currentPresetKey = useMemo((): string | null => {
     // ADR-040: elementsMap O(1) 조회
     const body = elementsMap.get(bodyElementId);
-    if (!body) {
-      if (import.meta.env.DEV) {
-        console.log(
-          "[ADR-911 diag][usePresetApply] body 없음 — bodyElementId:",
-          bodyElementId,
-        );
-      }
-      return null;
-    }
+    if (!body) return null;
 
     const appliedPreset = (body.props as { appliedPreset?: string })
       ?.appliedPreset;
@@ -122,39 +114,12 @@ export function usePresetApply({
         existingSlotNames.size === presetSlotNames.size &&
         [...existingSlotNames].every((name) => presetSlotNames.has(name))
       ) {
-        if (import.meta.env.DEV) {
-          console.log("[ADR-911 diag][usePresetApply] currentPresetKey =", {
-            bodyElementId,
-            layoutId,
-            appliedPreset,
-            existingSlotNames: [...existingSlotNames],
-            presetSlotNames: [...presetSlotNames],
-            match: true,
-          });
-        }
         return appliedPreset;
       }
-
-      if (import.meta.env.DEV) {
-        console.log("[ADR-911 diag][usePresetApply] slot mismatch:", {
-          bodyElementId,
-          layoutId,
-          appliedPreset,
-          existingSlotNames: [...existingSlotNames],
-          presetSlotNames: [...presetSlotNames],
-        });
-      }
-    } else if (import.meta.env.DEV) {
-      console.log(
-        "[ADR-911 diag][usePresetApply] appliedPreset 없음/unknown — bodyElementId:",
-        bodyElementId,
-        "appliedPreset:",
-        appliedPreset,
-      );
     }
 
     return null;
-  }, [elementsMap, bodyElementId, existingSlots, layoutId]);
+  }, [elementsMap, bodyElementId, existingSlots]);
 
   // 프리셋 적용 함수
   const applyPreset = useCallback(


### PR DESCRIPTION
… cleanup

ADR-911 Phase 2 cutover 완료 + dev 검증 fix 2건 (PR #260 / #262) land 후 진단 로그가 root cause 확정 임무 완수. dev 콘솔 노이즈 해소.

제거된 진단 로그 6 블록:
- LayoutBodyEditor.tsx:32-43 — useMemo elementId 추적 1 블록
- usePresetApply.ts:97-157 — body 없음 / currentPresetKey match / slot mismatch / appliedPreset 없음/unknown 4 블록
- LayoutPresetSelector/index.tsx:63-72 — render 추적 1 블록

usePresetApply.currentPresetKey useMemo deps 정리:
- [elementsMap, bodyElementId, existingSlots, layoutId] → [elementsMap, bodyElementId, existingSlots]
- layoutId 는 진단 로그에서만 사용했으므로 deps 제거 정합

검증:
- type-check 3/3 PASS
- vitest: main HEAD 와 동일 4 사전 실패 (useFillActions / layoutActions P3-D-3 / cascade) — 본 작업과 무관, console.log 제거만으로 회귀 0
- 잔존 grep "ADR-911 diag" 0건