### PR TITLE
feat(adr-109-d1): Publish body element 자동 동기화 hook

### DIFF
--- a/apps/publish/src/hooks/useBodyElement.ts
+++ b/apps/publish/src/hooks/useBodyElement.ts
@@ -1,0 +1,102 @@
+/**
+ * useBodyElement — Publish body element DOM 동기화
+ *
+ * ADR-109 D1: Publish 의 body element 에 BodySpec className (`react-aria-Body`)
+ * 과 스타일을 document.body 에 주입하여 Preview DOM 과 대칭을 달성한다.
+ *
+ * Preview App.tsx 의 body useEffect 와 대칭되는 경량 버전.
+ * Publish 는 테마 토글이 없으므로 초기 마운트 + element 변경 시에만 동기화.
+ */
+
+import { useEffect, useRef } from "react";
+import type { Element } from "@composition/shared";
+import { adaptElementFillStyle } from "@composition/shared";
+
+const CSS_UNITLESS = new Set([
+  "opacity",
+  "fontWeight",
+  "zIndex",
+  "lineHeight",
+  "flexGrow",
+  "flexShrink",
+  "order",
+]);
+
+function camelToKebab(str: string): string {
+  return str.replace(/([A-Z])/g, (m) => `-${m.toLowerCase()}`);
+}
+
+/**
+ * Publish 페이지의 body element 를 document.body 에 동기화한다.
+ *
+ * - `react-aria-Body` className 주입 (spec-backed CSS selector 매칭)
+ * - body element 의 style 직접 주입 (backgroundColor / color 등 CSS var)
+ * - D3: fills 배열은 무시하고 Spec TokenRef 경로 (style.backgroundColor) 만 사용
+ */
+export function useBodyElement(elements: Element[]): void {
+  const appliedStyleKeysRef = useRef<Set<string>>(new Set());
+  const appliedClassNameRef = useRef<string>("");
+
+  useEffect(() => {
+    appliedStyleKeysRef.current.forEach((key) => {
+      document.body.style.removeProperty(key);
+    });
+    appliedStyleKeysRef.current.clear();
+
+    if (appliedClassNameRef.current) {
+      const current = document.body.className.split(" ");
+      const toRemove = appliedClassNameRef.current.split(" ");
+      document.body.className = current
+        .filter((cls) => !toRemove.includes(cls))
+        .join(" ")
+        .trim();
+      appliedClassNameRef.current = "";
+    }
+
+    // body element 찾기 (page-level: layout_id 없음 + parent_id 없음)
+    const bodyElement = elements.find(
+      (el) => el.type === "body" && !el.parent_id && !el.deleted,
+    );
+
+    if (!bodyElement) return;
+
+    // D3: fills 를 무시하고 Spec TokenRef 경로 (style.backgroundColor) 만 적용
+    const adaptedBody = adaptElementFillStyle(bodyElement);
+
+    // D1: BodySpec className 주입 — `.react-aria-Body { ... }` CSS 규칙 매칭
+    const specClassName = "react-aria-Body";
+    document.body.className =
+      `${document.body.className} ${specClassName}`.trim();
+    appliedClassNameRef.current = specClassName;
+
+    if (adaptedBody.props?.style) {
+      const style = adaptedBody.props.style as Record<string, string | number>;
+      Object.entries(style).forEach(([key, value]) => {
+        const cssKey = camelToKebab(key);
+        const cssValue =
+          typeof value === "number" && !CSS_UNITLESS.has(key)
+            ? `${value}px`
+            : String(value);
+        document.body.style.setProperty(cssKey, cssValue);
+        appliedStyleKeysRef.current.add(cssKey);
+      });
+    }
+
+    const styleKeysToClean = new Set(appliedStyleKeysRef.current);
+    const classNameToClean = appliedClassNameRef.current;
+
+    return () => {
+      styleKeysToClean.forEach((key) => {
+        document.body.style.removeProperty(key);
+      });
+      if (classNameToClean) {
+        const current = document.body.className.split(" ");
+        const toRemove = classNameToClean.split(" ");
+        document.body.className = current
+          .filter((cls) => !toRemove.includes(cls))
+          .join(" ")
+          .trim();
+      }
+    };
+  }, [elements]);
+}

--- a/apps/publish/src/renderer/PageRenderer.tsx
+++ b/apps/publish/src/renderer/PageRenderer.tsx
@@ -8,10 +8,11 @@
  * @since 2025-12-11 Phase 10 B2.3
  */
 
-import { memo, useMemo } from 'react';
-import type { Element, Page } from '@composition/shared';
-import { buildElementTree } from '@composition/shared';
-import { ElementRenderer } from './ElementRenderer';
+import { memo, useMemo } from "react";
+import type { Element, Page } from "@composition/shared";
+import { buildElementTree } from "@composition/shared";
+import { ElementRenderer } from "./ElementRenderer";
+import { useBodyElement } from "../hooks/useBodyElement";
 
 // ============================================
 // Types
@@ -43,6 +44,9 @@ export const PageRenderer = memo(function PageRenderer({
   const rootElements = useMemo(() => {
     return buildElementTree(pageElements, null);
   }, [pageElements]);
+
+  // ADR-109 D1: body element → document.body className/style 동기화
+  useBodyElement(pageElements);
 
   return (
     <div


### PR DESCRIPTION
ADR-109 D1 (Publish className 주입) 한정 land:

- useBodyElement(elements) hook 신설 — body element → document.body 에 `react-aria-Body` className + style 직접 주입 (CSS var 자연 적용)
- PageRenderer 에서 hook 호출 추가 (page-level body element 자동 탐지)
- D3 부분 충족: fills 배열 무시 + Spec TokenRef 경로(style.backgroundColor) 사용
- 정리(cleanup) 로직: unmount 시 className + style 모두 제거

잔여 (별도 PR):
- D2: createDefaultBodyProps 의 backgroundColor "var(--bg)" literal 제거
- D3: body.fills runtime-ignore 안정성 검증 + fill inspector body=theme-managed
- D4: SkiaRenderer.backgroundColor + setupThemeWatcher cleanup
- Gate G1~G4: cross-check + Chrome MCP 실측

검증:
- pnpm --filter @composition/publish exec tsc --noEmit → exit 0

(ADR-109 partial — Implemented 승격은 D2~D4 + Gate 완결 시점)