### PR TITLE
feat(adr-109)!: Body Spec SSOT D2/D4 land + Implemented 승격

### DIFF
--- a/apps/builder/src/builder/workspace/canvas/BuilderCanvas.tsx
+++ b/apps/builder/src/builder/workspace/canvas/BuilderCanvas.tsx
@@ -75,8 +75,6 @@ export interface BuilderCanvasProps {
   pageWidth?: number;
   /** 페이지 영역 높이 (breakpoint 크기) */
   pageHeight?: number;
-  /** 배경색 */
-  backgroundColor?: number;
   /** 초기 Pan Offset X (비교 모드 등에서 사용) */
   initialPanOffsetX?: number;
 }
@@ -87,7 +85,6 @@ export interface BuilderCanvasProps {
 
 const DEFAULT_WIDTH = 1920;
 const DEFAULT_HEIGHT = 1080;
-const DEFAULT_BACKGROUND = 0xf3f4f6; // gray-100 (PixiJS용, Skia는 opaque + MutationObserver로 --bg 동기화)
 const PAGE_STACK_GAP = 80;
 
 // ============================================
@@ -109,7 +106,6 @@ const SkiaCanvasComponent = lazy(skiaCanvasImport);
 
 function SkiaCanvasLazy(props: {
   containerEl: HTMLDivElement;
-  backgroundColor?: number;
   invalidateLayout: () => void;
   sceneInvalidationPacket: RendererSceneInvalidation;
   rendererInput: SkiaRendererInput;
@@ -130,7 +126,6 @@ function SkiaCanvasLazy(props: {
 export function BuilderCanvas({
   pageWidth = DEFAULT_WIDTH,
   pageHeight = DEFAULT_HEIGHT,
-  backgroundColor = DEFAULT_BACKGROUND,
   initialPanOffsetX,
 }: BuilderCanvasProps) {
   // Dev-only: rAF 기반 FPS/프레임타임 측정(렌더 idle 여부와는 별개)
@@ -687,7 +682,6 @@ export function BuilderCanvas({
       {containerEl && (
         <SkiaCanvasLazy
           containerEl={containerEl}
-          backgroundColor={backgroundColor}
           invalidateLayout={invalidateLayout}
           sceneInvalidationPacket={sceneInvalidationPacket}
           rendererInput={skiaRendererInput}

--- a/apps/builder/src/builder/workspace/canvas/skia/SkiaCanvas.tsx
+++ b/apps/builder/src/builder/workspace/canvas/skia/SkiaCanvas.tsx
@@ -31,11 +31,7 @@ import {
 } from "../renderers";
 import type { DropIndicatorSnapshot } from "../selection/dropTargetResolver";
 import { recordInvalidation } from "./renderInvalidation";
-import {
-  readCssBgColor,
-  hexToColor4fChannels,
-  setupThemeWatcher,
-} from "./themeWatcher";
+import { setupThemeWatcher } from "./themeWatcher";
 import {
   setPagePosStaleFrames,
   tickPagePosStaleFrames,
@@ -84,8 +80,6 @@ import "../benchmarks/devProfiler";
 export interface SkiaCanvasProps {
   /** 부모 컨테이너 DOM 요소 */
   containerEl: HTMLDivElement;
-  /** 배경색 (hex) */
-  backgroundColor?: number;
   /** PixiJS Application (과도기 호환, 미사용) */
   app?: unknown;
   /** Layout 무효화 콜백 */
@@ -127,7 +121,6 @@ export interface SkiaCanvasProps {
  */
 export function SkiaCanvas({
   containerEl,
-  backgroundColor = 0xf3f4f6,
   app,
   invalidateLayout,
   sceneInvalidationPacket,
@@ -413,21 +406,16 @@ export function SkiaCanvas({
     skiaCanvas.style.width = `${rect.width}px`;
     skiaCanvas.style.height = `${rect.height}px`;
 
-    // 배경색
-    const resolvedBg = readCssBgColor(containerEl) ?? backgroundColor;
-    const r = ((resolvedBg >> 16) & 0xff) / 255;
-    const g = ((resolvedBg >> 8) & 0xff) / 255;
-    const b = (resolvedBg & 0xff) / 255;
-    const bgColor = ck.Color4f(r, g, b, 1);
-
-    const renderer = new SkiaRenderer(ck, skiaCanvas, bgColor, dpr);
+    // ADR-109 D4: SkiaRenderer.backgroundColor field cleanup. ADR-902 이후
+    // clearFrame() 이 투명 clear 로 동작하고 body fill 은 element tree (BodySpec) 가
+    // 담당하므로 renderer 가 background color 를 보유할 필요 없음.
+    const renderer = new SkiaRenderer(ck, skiaCanvas, dpr);
     rendererRef.current = renderer;
 
-    // 테마 변경 동기화
+    // 테마 변경 동기화 — Skia 캐시 무효화 + invalidation 트리거 (background color 직접
+    // 갱신은 BodySpec TokenRef resolve 가 자동 처리, 본 watcher 는 frame 재렌더만 보장)
     const themeWatcherHandle = setupThemeWatcher(containerEl, {
-      onThemeChange: (hex) => {
-        const [rv, gv, bv] = hexToColor4fChannels(hex);
-        renderer.setBackgroundColor(ck.Color4f(rv, gv, bv, 1));
+      onThemeChange: () => {
         renderer.invalidateContent();
         recordInvalidation("theme", "builderThemeChange");
       },
@@ -777,7 +765,7 @@ export function SkiaCanvas({
       renderer.dispose();
       rendererRef.current = null;
     };
-  }, [ready, containerEl, backgroundColor, dropIndicatorSnapshotRef]);
+  }, [ready, containerEl, dropIndicatorSnapshotRef]);
 
   // 페이지 전환 시 오버레이 갱신
   const prevPageIdRef = useRef(

--- a/apps/builder/src/builder/workspace/canvas/skia/SkiaRenderer.ts
+++ b/apps/builder/src/builder/workspace/canvas/skia/SkiaRenderer.ts
@@ -32,7 +32,6 @@ export class SkiaRenderer {
   private contentNode: SkiaRenderable | null = null;
   private overlayNode: SkiaRenderable | null = null;
   private screenOverlayNode: SkiaRenderable | null = null;
-  private backgroundColor: Float32Array;
   private disposed = false;
   private dpr: number;
 
@@ -94,12 +93,7 @@ export class SkiaRenderer {
   public transitionManager: TransitionManager | null = null;
   public animationEngine: AnimationEngine | null = null;
 
-  constructor(
-    ck: CanvasKit,
-    htmlCanvas: HTMLCanvasElement,
-    backgroundColor?: Float32Array,
-    dpr?: number,
-  ) {
+  constructor(ck: CanvasKit, htmlCanvas: HTMLCanvasElement, dpr?: number) {
     this.ck = ck;
     this.dpr = dpr ?? (window.devicePixelRatio || 1);
     this.contentPaddingDevicePx = Math.round(
@@ -107,7 +101,6 @@ export class SkiaRenderer {
     );
     this.mainSurface = createGPUSurface(ck, htmlCanvas);
     this.mainCanvas = this.mainSurface.getCanvas();
-    this.backgroundColor = backgroundColor ?? ck.Color4f(1, 1, 1, 1);
 
     if (process.env.NODE_ENV === "development") {
       this.devContentRenderWindowStartMs = performance.now();
@@ -128,11 +121,6 @@ export class SkiaRenderer {
   /** 씬 좌표계 오버레이(그리드 등) 렌더러를 설정한다. 카메라 변환이 적용된다. */
   setScreenOverlayNode(node: SkiaRenderable | null): void {
     this.screenOverlayNode = node;
-  }
-
-  /** 배경색을 변경한다. */
-  setBackgroundColor(color: Float32Array): void {
-    this.backgroundColor = color;
   }
 
   /** 컨텐츠 캐시를 무효화하여 다음 프레임에서 전체 재렌더링하도록 한다. */

--- a/apps/builder/src/types/builder/unified.types.ts
+++ b/apps/builder/src/types/builder/unified.types.ts
@@ -1764,20 +1764,20 @@ export function createDefaultDivProps(): DivElementProps {
 }
 
 export function createDefaultBodyProps(): DivElementProps {
-  // ADR-902 후속: 리터럴 hex 대신 CSS var 를 직접 저장. 3 consumer 동작:
-  // - Skia: BodySpec (TAG_SPEC_MAP 등록) 가 buildSpecNodeData 경로로 담당 →
-  //   style.backgroundColor 미사용, Spec TokenRef ({color.base}) 가 theme resolve.
-  // - Preview DOM: document.body.style.backgroundColor = "var(--bg)" → CSS cascade 로
-  //   theme-aware (BODY_THEME_MAP 하드코딩 불필요).
-  // - Publish DOM: 동일 — 브라우저가 CSS var 해석 → theme-aware (publish CSS 변수 scope 의존).
-  // normalizeExternalFillIngress.migrateBackgroundColor 는 "var(" prefix 를 skip 하므로
-  // fills auto-migrate 안 일어남 → 리터럴 유지 + Spec 경로와 무충돌.
+  // ADR-109 D2: backgroundColor / color CSS var 리터럴 제거. className "react-aria-Body"
+  // 자동 주입으로 BodySpec generated CSS (.react-aria-Body { background: var(--bg); color: var(--fg); })
+  // 가 theme 적용을 담당. 3 consumer 동작:
+  // - Skia: BodySpec (TAG_SPEC_MAP 등록) 가 buildSpecNodeData 경로로 담당 → Spec TokenRef
+  //   ({color.base} / {color.neutral}) 가 theme resolve.
+  // - Preview DOM: App.tsx 가 props.className "react-aria-Body" 를 document.body 에 주입 →
+  //   generated CSS rule 로 theme-aware (CSS cascade).
+  // - Publish DOM: useBodyElement(elements) hook 이 react-aria-Body className + props.style 을
+  //   document.body 에 주입 → 동일 generated CSS rule 적용.
   return {
+    className: "react-aria-Body",
     style: {
       display: "block",
       fontFamily: `"Pretendard", "Inter Variable", monospace, system-ui, sans-serif`,
-      color: "var(--fg)",
-      backgroundColor: "var(--bg)",
       overflow: "auto",
     },
   };

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Body Spec SSOT 완결 — ADR-109 Publish symmetry + D1/D2/D4] - 2026-04-27
+
+### Architecture
+
+- **ADR-109 Implemented — Body Spec SSOT 완결 + Publish consumer 대칭 복구**:
+  - **D1** (PR #268, commit `40a17a03`): Publish `useBodyElement(elements)` hook 신설 (102줄) — body element → `document.body` className `react-aria-Body` + style 직접 주입 + cleanup 로직. `apps/publish/src/hooks/useBodyElement.ts` + `apps/publish/src/renderer/PageRenderer.tsx` 통합
+  - **D2**: `createDefaultBodyProps` 의 `backgroundColor: "var(--bg)"` / `color: "var(--fg)"` literal 제거 + `className: "react-aria-Body"` 추가
+    - **Why**: D2 의 inline CSS var literal 은 Preview/Publish 양쪽에서 className `react-aria-Body` 자동 주입 + generated CSS rule (`.react-aria-Body { background: var(--bg); color: var(--fg); }`) 로 대체 가능. literal 제거로 ADR-063 D3 symmetric 회복 (한쪽이 기준이 아닌 spec 파생)
+    - 위치: `apps/builder/src/types/builder/unified.types.ts:1766`
+  - **D4**: SkiaRenderer.backgroundColor field + setBackgroundColor 메서드 + SkiaCanvas/BuilderCanvas backgroundColor prop dead code cleanup
+    - **Why**: ADR-902 이후 `clearFrame()` 투명 clear + element tree body fill 처리로 backgroundColor 가 read 되지 않음 (assignment 만 잔존, dead chain). 호출자 SkiaCanvas.tsx 1곳 → 완전 제거 안전
+    - 위치: `apps/builder/src/builder/workspace/canvas/skia/SkiaRenderer.ts` / `SkiaCanvas.tsx` / `apps/builder/src/builder/workspace/canvas/BuilderCanvas.tsx`
+  - **D3 + Gate G3 Defer** (Phase 3 별도 follow-up): body.fills runtime-ignore 안정성 검증 + fill inspector body="theme-managed" UI 미구현. ADR-109 Gate G3 의 "실패 시 대안: Phase 3 을 defer 로 분리 — 사용자-가시 영향 없으므로 optional" 적용. BodySpec.shapes 의 var/{/$-- prefix skip 로직이 이미 fills runtime-ignore 동등 동작 보장
+  - **검증**: Gate G1 (publish 회귀 0) — `pnpm type-check` 3/3 exit 0 / Gate G2 (3경로 theme 대칭) — className 자동 주입 + BodySpec TokenRef resolve / Gate G4 (D4 cleanup 안전성) — `setBackgroundColor` / `SkiaRenderer.backgroundColor` field grep 0건
+  - ADR-902 후속 body SSOT 스토리라인 완결 (Skia/Preview/Publish 3경로 1 Spec 파생)
+
 ## [DesignKit 시스템 제거 — Theme/Variable 시스템 중복 해소 — ADR-915] - 2026-04-27
 
 ### Breaking Changes

--- a/docs/adr/109-body-spec-ssot-completion-publish-symmetry.md
+++ b/docs/adr/109-body-spec-ssot-completion-publish-symmetry.md
@@ -2,7 +2,32 @@
 
 ## Status
 
-Proposed — 2026-04-25
+Implemented — 2026-04-25 → 2026-04-27
+
+### 진행 로그
+
+- **2026-04-25**: Proposed (D1~D4 4 debt + Gate G1~G4 정의)
+- **2026-04-27 (세션 40)**: **D1 land** (PR #268, commit `40a17a03`)
+  - `apps/publish/src/hooks/useBodyElement.ts` 신규 (102줄) — body element → `document.body` className `react-aria-Body` + style 직접 주입 + cleanup
+  - `apps/publish/src/renderer/PageRenderer.tsx` — `useBodyElement(pageElements)` 호출 추가
+  - 검증: publish type-check exit 0
+- **2026-04-27 (세션 41)**: **D2 + D4 land + Implemented 승격**
+  - **D2** (`apps/builder/src/types/builder/unified.types.ts:1766` `createDefaultBodyProps`):
+    - `style.backgroundColor: "var(--bg)"` literal 제거
+    - `style.color: "var(--fg)"` literal 제거
+    - `className: "react-aria-Body"` 추가 — Preview/Publish 양쪽에서 generated CSS rule (`.react-aria-Body { background: var(--bg); color: var(--fg); }`) 적용
+  - **D4** (Skia renderer dead code cleanup):
+    - `SkiaRenderer.backgroundColor` private field + constructor param + `setBackgroundColor()` 메서드 제거
+    - `SkiaCanvas.tsx` `backgroundColor` prop + `readCssBgColor` / `hexToColor4fChannels` import + bgColor 계산 블록 제거
+    - `BuilderCanvas.tsx` `backgroundColor` prop + `DEFAULT_BACKGROUND` const + 호출처 전달 제거
+    - `setupThemeWatcher` callback 단순화 (setBackgroundColor 호출 제거 — invalidateContent + recordInvalidation 만)
+  - **Gate G1 (publish 회귀 0) PASS** — `pnpm type-check` 3/3 exit 0
+  - **Gate G2 (body 3경로 theme 대칭) PASS** — D2 className 자동 주입으로 generated CSS 통일 (Builder Skia 는 BodySpec.shapes var prefix skip + TokenRef resolve 기존 동작 유지)
+  - **Gate G4 (D4 cleanup 안전성) PASS** — `setBackgroundColor` / `SkiaRenderer.backgroundColor` field grep 0건 (themeWatcher.ts 의 readCssBgColor 내부 helper 사용은 별개)
+  - **D3 + Gate G3 Defer** (Phase 3 별도 follow-up):
+    - body.fills runtime-ignore 안정성 검증 + fill inspector body="theme-managed" 표시 (또는 fills 편집 UI 차단) 미구현
+    - ADR-109 R3 + Gate G3 의 "실패 시 대안: Phase 3 을 defer 로 분리 — 사용자-가시 영향 없으므로 optional" 적용
+    - BodySpec.shapes 의 `var(`/`{`/`$--` prefix skip 로직이 이미 fills runtime-ignore 동등 동작 보장 → defer 안전
 
 ## Context
 


### PR DESCRIPTION
ADR-109 D2 + D4 + Gate G1/G2/G4 통과 → Status `Proposed → Implemented`.

D2 (createDefaultBodyProps literal 제거):
- backgroundColor "var(--bg)" / color "var(--fg)" literal 제거
- className "react-aria-Body" 추가 — Preview/Publish 양쪽에서 generated CSS rule (.react-aria-Body { background: var(--bg); color: var(--fg); }) 적용
- Why: ADR-063 D3 symmetric 회복 — literal 대신 spec 파생 CSS

D4 (SkiaRenderer dead code cleanup):
- SkiaRenderer.backgroundColor field + setBackgroundColor 메서드 제거
- SkiaCanvas backgroundColor prop + readCssBgColor/hexToColor4fChannels import 제거
- BuilderCanvas backgroundColor prop + DEFAULT_BACKGROUND const 제거
- setupThemeWatcher callback 단순화 (setBackgroundColor 호출 제거)
- Why: ADR-902 이후 clearFrame() 투명 clear + element tree body fill 처리로 backgroundColor read 0건 (assignment 만 잔존, dead chain)

D3 + Gate G3 Defer (Phase 3 별도 follow-up):
- body.fills runtime-ignore 안정성 검증 + fill inspector body=theme-managed UI 미구현
- BodySpec.shapes 의 var/{/$-- prefix skip 로직이 이미 동등 동작 보장
- ADR-109 Gate G3 "실패 시 대안: Phase 3 을 defer 로 분리" 적용

검증:
- Gate G1: pnpm type-check 3/3 exit 0 (builder + publish + shared)
- Gate G2: className 자동 주입 + BodySpec TokenRef resolve 기존 동작 유지
- Gate G4: setBackgroundColor / SkiaRenderer.backgroundColor field grep 0건
- vitest: skia 영역 59/59 PASS

BREAKING CHANGE: BuilderCanvas / SkiaCanvas 의 backgroundColor prop 제거
  (외부 호출처 0건 → 영향 없음)