### PR TITLE
fix(adr-911): 복합 컴포넌트 page_id/layout_id 미주입 회귀 수정

### DIFF
--- a/apps/builder/src/builder/factories/ComponentFactory.ts
+++ b/apps/builder/src/builder/factories/ComponentFactory.ts
@@ -235,7 +235,13 @@ export class ComponentFactory {
     const definition = definitionCreator(context);
 
     // 2. Element 데이터 생성
-    const { parent, children } = createElementsFromDefinition(definition);
+    // ADR-911 P2 fix (2026-04-27 세션 42): pageId/layoutId 명시 전달.
+    // canonical mode default true 후 page_id 미주입 element 가 page-indexed
+    // 분기에서 누락되어 화면 렌더 실패하던 회귀 해소.
+    const { parent, children } = createElementsFromDefinition(definition, {
+      pageId: pageId || null,
+      layoutId,
+    });
 
     // 3. 스토어에 추가 (즉시 UI 업데이트)
     addElementsToStore(parent, children);

--- a/apps/builder/src/builder/factories/utils/elementCreation.ts
+++ b/apps/builder/src/builder/factories/utils/elementCreation.ts
@@ -8,10 +8,30 @@ import { sanitizeElement } from "../../stores/utils/elementSanitizer";
 import { applyFactoryPropagation } from "../../utils/propagationEngine";
 
 /**
+ * 컴포넌트 정의로부터 실제 Element 데이터 생성 시 필요한 컨텍스트.
+ *
+ * **ADR-911 P2 cutover 후 회귀 fix (2026-04-27 세션 42)**:
+ * canonical mode default true 환경에서 page_id/layout_id 미주입 element 는
+ * `pageElementsSnapshot` / `selectCanonicalDocument` 의 page-indexed 분기에서
+ * 누락되어 화면 렌더 실패. createElementsFromDefinition 가 caller (ComponentFactory)
+ * 의 pageId/layoutId 를 받아 parent + children 모두에 명시 주입한다.
+ *
+ * Layout/Slot System: layoutId 가 있으면 page_id=null, 없으면 page_id=pageId.
+ * useElementCreator 의 단순 컴포넌트 경로 (line 198) 와 동일 규칙.
+ */
+export interface ElementCreationContext {
+  pageId: string | null;
+  layoutId: string | null | undefined;
+}
+
+/**
  * 컴포넌트 정의로부터 실제 Element 데이터 생성
  * 재귀적 중첩 children 지원 (TagGroup → TagList → Tag 등 3레벨 이상)
  */
-export function createElementsFromDefinition(definition: ComponentDefinition): {
+export function createElementsFromDefinition(
+  definition: ComponentDefinition,
+  context?: ElementCreationContext,
+): {
   parent: Element;
   children: Element[];
 } {
@@ -19,11 +39,19 @@ export function createElementsFromDefinition(definition: ComponentDefinition): {
   const store = useStore.getState();
   const currentElements = store.elements;
 
+  // ADR-911 P2 fix: page_id/layout_id 명시 주입 (canonical mode 에서 page-indexed 누락 방지)
+  // useElementCreator.ts:198 의 단순 컴포넌트 경로와 동일 규칙
+  const pageId = context?.pageId ?? null;
+  const layoutId = context?.layoutId ?? null;
+  const resolvedPageId = layoutId ? null : pageId;
+
   // 부모 요소 생성
   const parent: Element = {
     ...definition.parent,
     id: ElementUtils.generateId(),
     customId: generateCustomId(definition.parent.type, currentElements),
+    page_id: resolvedPageId,
+    layout_id: layoutId,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
   };
@@ -43,6 +71,8 @@ export function createElementsFromDefinition(definition: ComponentDefinition): {
         id: ElementUtils.generateId(),
         customId: generateCustomId(elementDef.type, allElementsSoFar),
         parent_id: parentId,
+        page_id: resolvedPageId,
+        layout_id: layoutId,
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       };

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [ADR-911 P2 회귀 수정 — 복합 컴포넌트 등록 시 page_id 미주입으로 화면 누락] - 2026-04-27
+
+### Bug Fixes
+
+- **복합 컴포넌트 (ListBox / TagGroup / RadioGroup / CheckboxGroup 등 COMPLEX_COMPONENT_TAGS) 등록 시 화면 미렌더 회귀**:
+  - 사용자 보고 (세션 42): ListBox 컴포넌트 등록 후 화면에 element 가 나타나지 않음 + dev console `[ADR-903] sanitizeElement: page_id/layout_id 없음 — canonical parent 의존 element?` 경고
+  - **Why**: `createElementsFromDefinition` (`apps/builder/src/builder/factories/utils/elementCreation.ts`) 가 parent + children Element 객체 생성 시 `page_id` / `layout_id` 명시 주입 안 함. ADR-911 P2 cutover (canonical mode default true) 후 `pageElementsSnapshot` / `selectCanonicalDocument` 의 page-indexed 분기에서 page_id 없는 element 가 frame.children 에 attach 안 되어 화면 누락. 단순 컴포넌트 경로 (`useElementCreator.ts:198`) 는 정상 (page_id 명시 주입) — 두 경로 비대칭이 ADR-911 cutover 로 노출됨
+  - 수정: `createElementsFromDefinition` 시그니처에 `ElementCreationContext` (pageId / layoutId) 추가 + parent + children 모두에 `page_id: layoutId ? null : pageId` / `layout_id: layoutId` 명시 주입. `ComponentFactory.createComponent` 가 호출 시 이미 보유 중인 pageId/layoutId 전달
+  - 위치: `apps/builder/src/builder/factories/utils/elementCreation.ts` (createElementsFromDefinition + ElementCreationContext 인터페이스 신설) / `apps/builder/src/builder/factories/ComponentFactory.ts:238-245` (호출 시 context 전달)
+  - 검증: `pnpm type-check` 3/3 exit 0
+  - **ADR-911 monitoring 1주 (~2026-05-04) 진행 중 발견된 사용자-가시 회귀** — 본 fix land 후 monitoring 카운터 reset 권장 (회귀 fix 시점부터 1주 재측정 + 추가 회귀 watch)
+
 ## [ADR-913 mechanical rename false-positive sweep — Tag literal 복원 + lucide generated 자동화] - 2026-04-27
 
 ### Bug Fixes


### PR DESCRIPTION
ADR-911 P2 cutover (canonical mode default true) 후 사용자-가시 회귀:
- ListBox 등 COMPLEX_COMPONENT_TAGS 컴포넌트 등록 시 화면 미렌더
- dev console: [ADR-903] sanitizeElement page_id/layout_id 없음 경고

Root cause:
- createElementsFromDefinition 이 parent + children Element 생성 시 page_id / layout_id 명시 주입 안 함
- 단순 컴포넌트 경로 (useElementCreator.ts:198) 와 비대칭 (단순 경로 = page_id: layoutId ? null : currentPageId 명시)
- canonical mode 에서 page_id 없는 element 가 frame.children attach 실패 → pageElementsSnapshot / selectCanonicalDocument page-indexed 분기 누락

Fix:
- createElementsFromDefinition 시그니처에 ElementCreationContext (pageId/layoutId) 추가
- parent + children 모두에 page_id / layout_id 명시 주입
- ComponentFactory.createComponent 가 호출 시 이미 보유 중인 pageId/layoutId 전달

검증:
- pnpm type-check 3/3 exit 0

ADR-911 monitoring 1주 진행 중 발견된 회귀 — fix land 후 monitoring 카운터 reset 권장.