### PR TITLE
Cache calendar Intl.DateTimeFormat and narrow grid full-rebuild trigger

### DIFF
--- a/apps/builder/src/builder/factories/definitions/DateColorComponents.ts
+++ b/apps/builder/src/builder/factories/definitions/DateColorComponents.ts
@@ -2,19 +2,33 @@ import { ComponentElementProps } from "../../../types/core/store.types";
 import { HierarchyManager } from "../../utils/HierarchyManager";
 import { ComponentDefinition, ComponentCreationContext } from "../types";
 
+const CALENDAR_MONTH_FORMATTERS = new Map<string, Intl.DateTimeFormat>();
+
+function getCalendarMonthFormatter(locale: string): Intl.DateTimeFormat {
+  const cached = CALENDAR_MONTH_FORMATTERS.get(locale);
+  if (cached) return cached;
+
+  const formatter = new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "long",
+  });
+  CALENDAR_MONTH_FORMATTERS.set(locale, formatter);
+  return formatter;
+}
+
 /** Calendar 현재 월 초기 데이터 (DatePicker/DateRangePicker/Calendar 공유) */
 function buildCalendarInitData() {
   const now = new Date();
   const calYear = now.getFullYear();
   const calMonth = now.getMonth();
+  const locale =
+    (typeof navigator !== "undefined" && navigator.language) || "ko-KR";
+  const formatter = getCalendarMonthFormatter(locale);
   return {
     now,
     firstDay: new Date(calYear, calMonth, 1).getDay(),
     calTotalDays: new Date(calYear, calMonth + 1, 0).getDate(),
-    monthText: new Intl.DateTimeFormat(
-      (typeof navigator !== "undefined" && navigator.language) || "ko-KR",
-      { year: "numeric", month: "long" },
-    ).format(now),
+    monthText: formatter.format(now),
   };
 }
 

--- a/apps/builder/src/builder/factories/definitions/DisplayComponents.ts
+++ b/apps/builder/src/builder/factories/definitions/DisplayComponents.ts
@@ -2,6 +2,21 @@ import { ComponentElementProps } from "../../../types/core/store.types";
 import { HierarchyManager } from "../../utils/HierarchyManager";
 import { ComponentDefinition, ComponentCreationContext } from "../types";
 
+const RANGE_CALENDAR_MONTH_FORMATTERS = new Map<string, Intl.DateTimeFormat>();
+
+function formatRangeCalendarMonth(date: Date): string {
+  const locale = navigator.language || "ko-KR";
+  const cached = RANGE_CALENDAR_MONTH_FORMATTERS.get(locale);
+  if (cached) return cached.format(date);
+
+  const formatter = new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "long",
+  });
+  RANGE_CALENDAR_MONTH_FORMATTERS.set(locale, formatter);
+  return formatter.format(date);
+}
+
 /**
  * Avatar 컴포넌트 정의
  *
@@ -653,10 +668,7 @@ export function createRangeCalendarDefinition(
       {
         type: "CalendarHeader",
         props: {
-          children: new Intl.DateTimeFormat(navigator.language || "ko-KR", {
-            year: "numeric",
-            month: "long",
-          }).format(now),
+          children: formatRangeCalendarMonth(now),
         } as ComponentElementProps,
         order_num: 1,
       },

--- a/apps/builder/src/builder/workspace/canvas/layout/engines/fullTreeLayout.ts
+++ b/apps/builder/src/builder/workspace/canvas/layout/engines/fullTreeLayout.ts
@@ -315,6 +315,22 @@ function isGridDisplay(display: unknown): boolean {
   return display === "grid" || display === "inline-grid";
 }
 
+/**
+ * Grid full rebuild 강제 조건.
+ *
+ * - 자식이 있는 grid container 는 Taffy incremental add/update 경로에서
+ *   track/placement 캐시 invalidation 이 충분하지 않아 full rebuild 필요.
+ * - 자식이 없는 leaf grid 는 auto-placement/track 재배치 이슈 영향이 없으므로
+ *   incremental 경로를 허용해 등록 시 불필요한 전체 트리 rebuild를 회피한다.
+ */
+function shouldForceGridFullRebuild(
+  display: unknown,
+  childCount: number,
+): boolean {
+  if (!isGridDisplay(display)) return false;
+  return childCount > 0;
+}
+
 // ─── Implicit Style 패치 ──────────────────────────────────────────────
 
 /** CSS dimension 속성 (number → "${v}px" 변환) */
@@ -1881,11 +1897,11 @@ export function calculateFullTreeLayout(
       for (const node of batch) {
         const prevJson = persistentTree.getLastJson(node.elementId);
         const curDisplay = node.style.display;
-        // 신규 노드 (prevJson 없음) 가 grid container 면 full rebuild 필요 —
+        // 신규 노드 (prevJson 없음) 가 "자식이 있는 grid container" 면 full rebuild 필요 —
         // Taffy WASM `addNode` 증분 추가로는 grid track (gridTemplateColumns/Areas)
         // 이 auto-placement 로 degrade 됨. `buildFull` 로만 정상 배치.
         if (!prevJson) {
-          if (isGridDisplay(curDisplay)) {
+          if (shouldForceGridFullRebuild(curDisplay, node.children.length)) {
             needsFullRebuild = true;
             break;
           }
@@ -1900,7 +1916,7 @@ export function calculateFullTreeLayout(
         // track/placement 캐시 invalidation 실패 (padding 변경→1줄 degrade,
         // gap 변경→미반영). GRID_REBUILD_TRIGGER_KEYS 중 하나라도 변경 시
         // full rebuild 강제.
-        if (isGridDisplay(curDisplay)) {
+        if (shouldForceGridFullRebuild(curDisplay, node.children.length)) {
           let gridChanged = false;
           for (const k of GRID_REBUILD_TRIGGER_KEYS) {
             if (

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to composition will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Skia 캘린더 컴포넌트 등록 경량화 — 월 포맷터 재사용] - 2026-04-27
+
+### Performance
+
+- Skia full tree layout의 grid rebuild 조건을 세분화하여, **자식이 없는 leaf grid 노드 신규 등록**은 incremental update 경로를 사용하도록 변경했습니다. 기존에는 display가 grid인 신규 노드면 항상 `persistentTree.reset() + buildFull()`이 실행되어 페이지 전체 재계산이 발생했습니다.
+  - 위치: `apps/builder/src/builder/workspace/canvas/layout/engines/fullTreeLayout.ts`
+- Calendar 계열 컴포넌트 등록 시 `Intl.DateTimeFormat` 인스턴스를 매번 새로 생성하던 경로를 locale 단위 캐시(Map) 재사용으로 변경하여, 다중 등록 시 누적 포맷터 생성 비용을 줄였습니다.
+  - 위치: `apps/builder/src/builder/factories/definitions/DateColorComponents.ts`
+  - 위치: `apps/builder/src/builder/factories/definitions/DisplayComponents.ts`
+
 ## [ADR-910 Implemented — Canonical `themes`/`variables` 필드 Land Plan 전체 종결] - 2026-04-27
 
 ### Architecture


### PR DESCRIPTION
### Motivation

- Reduce repeated allocation of `Intl.DateTimeFormat` for calendar-related components to lower CPU and memory cost during many component registrations. 
- Avoid unnecessary full tree rebuilds in the Skia layout engine when registering leaf grid nodes to improve incremental update performance.

### Description

- Added locale-keyed formatter caches and helper functions `getCalendarMonthFormatter` and `formatRangeCalendarMonth` and replaced inline `new Intl.DateTimeFormat(...)` usage in `DateColorComponents.ts` and `DisplayComponents.ts` to reuse formatters. 
- Use `navigator.language` with fallback to `"ko-KR"` when selecting the locale for the cached formatters. 
- Introduced `shouldForceGridFullRebuild(display, childCount)` in `fullTreeLayout.ts` and replaced previous `isGridDisplay` checks so only grid containers with children force a full rebuild. 
- Updated logic that detects when a full rebuild is required to consult `shouldForceGridFullRebuild` instead of blindly forcing rebuilds for any grid display, reducing unnecessary `persistentTree.reset()` invocations. 

### Testing

- Ran TypeScript type-check (`tsc`) and the project build, and the checks completed successfully. 
- Executed the relevant builder unit/integration suites and smoke-tested the layout change paths; automated tests covering the modified areas passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef60a75b0c832a99c59c885960f5ff)